### PR TITLE
Ignore documentation in GitHub language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+SecurityShepherdCore/doc/** linguist-documentation


### PR DESCRIPTION
This repository is currently counted as a HTML project. This pull request should set it back to Java.
See [github/linguist](https://github.com/github/linguist) for more information on Linguist overrides.