### PR TITLE
Make sponsor bit.ly links https friendly

### DIFF
--- a/SecurityShepherdCore/src/utils/Analytics.java
+++ b/SecurityShepherdCore/src/utils/Analytics.java
@@ -31,10 +31,10 @@ public class Analytics
 			"<p>" +
 			bundle.getString("sponsorship.message.1") +
 			"<br/><br/>" +
-			"<a href=\"http://bit.ly/BccRiskAdvisorySite\"><img src=\"css/images/bccRiskAdvisorySmallLogo.jpg\" alt=\"BCC Risk Advisory\"/></a>" +
-			"<a href=\"http://bit.ly/EdgeScan\"><img src=\"css/images/edgescanSmallLogo.jpg\" alt=\"EdgeScan\" /></a>" +
+			"<a href=\"https://bit.ly/BccRiskAdvisorySite\"><img src=\"css/images/bccRiskAdvisorySmallLogo.jpg\" alt=\"BCC Risk Advisory\"/></a>" +
+			"<a href=\"https://bit.ly/EdgeScan\"><img src=\"css/images/edgescanSmallLogo.jpg\" alt=\"EdgeScan\" /></a>" +
 			"<br/>" +
-			"<a href=\"http://bit.ly/manicode\"><img src=\"css/images/manicode-logo.png\" style=\"margin-top: 5px;\"></a>" +
+			"<a href=\"https://bit.ly/manicode\"><img src=\"css/images/manicode-logo.png\" style=\"margin-top: 5px;\"></a>" +
 			"<br/><br/>" +
 			bundle.getString("sponsorship.message.2") +  
 			"<br/><a href=\"http://securityresearch.ie/\"><img src=\"https://www.owasp.org/images/thumb/2/24/Fontlogo.png/300px-Fontlogo.png\"/></a></p>");


### PR DESCRIPTION
Changes bit.ly sponsor links to HTTPS in order to make them friendly to
pure HTTPS deployments of Shepherd