### PR TITLE
enh: allow mongo connection string to be configurable via properties file

### DIFF
--- a/SecurityShepherdCore/site/WEB-INF/mongo.properties
+++ b/SecurityShepherdCore/site/WEB-INF/mongo.properties
@@ -1,0 +1,1 @@
+mongoConnectionString=mongodb://localhost:27017/

--- a/SecurityShepherdCore/src/servlets/module/challenge/NoSqlInjection1.java
+++ b/SecurityShepherdCore/src/servlets/module/challenge/NoSqlInjection1.java
@@ -9,8 +9,10 @@ import com.mongodb.DBObject;
 import com.mongodb.DBCollection;
 import com.mongodb.DBCursor;
 import com.mongodb.MongoClient;
+import com.mongodb.MongoClientURI;
 import com.mongodb.MongoCredential;
 import com.mongodb.MongoException;
+import dbProcs.FileInputProperties;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -95,7 +97,9 @@ public class NoSqlInjection1 extends HttpServlet
 				log.debug("Getting Connection to Mongo Database");
 				// To directly connect to a single MongoDB server (note that this will not auto-discover the primary even
 				// if it's a member of a replica set:
-				mongoClient = new MongoClient();
+                                String mongoProperties = getServletContext().getRealPath("") + "/WEB-INF/mongo.properties";
+                                String mongoConnectionString = FileInputProperties.readfile(mongoProperties, "mongoConnectionString");
+				mongoClient = new MongoClient(new MongoClientURI(mongoConnectionString));
 				
 				user = "gamer1";
 				database = "shepherdGames";


### PR DESCRIPTION
Mongo instance location could be configurable with the same mechanism the mysql instance is.
This would allow to deploy a mongo on a different location than the webapp (e.g. linked docker containers with one system on each).
This is what I think might be enough to make it configurable but as I'm on linux and the ant build script does not work properly (I'm assuming due to https://github.com/OWASP/SecurityShepherd/issues/266) I cannot build and verify that works as intended.
Any feedback would be greatly appreciated.