### PR TITLE
Update with base64 encoded value "userRole=administrator"

### DIFF
--- a/SecurityShepherdCore/src/servlets/module/challenge/SessionManagement1.java
+++ b/SecurityShepherdCore/src/servlets/module/challenge/SessionManagement1.java
@@ -88,7 +88,7 @@ public class SessionManagement1 extends HttpServlet
 				{
 					log.debug("Cookie value: " + theCookie.getValue());
 					
-					if(theCookie.getValue().equals("dXNlclJvbGU9YWRtaW5pc3RyYXRvcg"))
+					if(theCookie.getValue().equals("dXNlclJvbGU9YWRtaW5pc3RyYXRvcg=="))
 					{
 						log.debug("Challenge Complete");
 						// Get key and add it to the output


### PR DESCRIPTION
Without the actual `==`, the decoded value becomes `administrato`. admin or administrator would make sense, but letting the solution be a stripped down version of a keyword does not make sense (to me atleast)