### PR TITLE
Fix for Session Management 1 for Tomcat 8.5 Deployments

### DIFF
--- a/src/main/java/servlets/module/challenge/SessionManagement1.java
+++ b/src/main/java/servlets/module/challenge/SessionManagement1.java
@@ -12,6 +12,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+import org.apache.commons.codec.binary.Base64;
 import org.apache.log4j.Logger;
 
 import utils.Hash;
@@ -87,8 +88,11 @@ public class SessionManagement1 extends HttpServlet
 				if(theCookie != null)
 				{
 					log.debug("Cookie value: " + theCookie.getValue());
+					byte[] decodedCookieBytes = Base64.decodeBase64(theCookie.getValue());
+					String decodedCookie = new String(decodedCookieBytes, "UTF-8");
+					log.debug("Decoded Cookie: " + decodedCookie);
 					
-					if(theCookie.getValue().equals("dXNlclJvbGU9YWRtaW5pc3RyYXRvcg"))
+					if(decodedCookie.equals("userRole=administrator"))
 					{
 						log.debug("Challenge Complete");
 						// Get key and add it to the output


### PR DESCRIPTION
Looks like cookie.getValue() is a little unstable when it comes to padding and it looks like tomcat 8.5 (What the new docker image will use) will return the padding as well - Breaking the level. However there is no problem if instead of checking for a specific base64 encoded value; Decode the cookie and check if it is equal to the value we expect.

This implementation will not break previous deployments and will work on tomcat 7, 8 and 8.5