### PR TITLE
Fixing the hint for SQL Injection Escaping Challenge

### DIFF
--- a/src/main/webapp/challenges/8c3c35c30cdbbb73b7be3a4f8587aa9d88044dc43e248984a252c6e861f673d4.jsp
+++ b/src/main/webapp/challenges/8c3c35c30cdbbb73b7be3a4f8587aa9d88044dc43e248984a252c6e861f673d4.jsp
@@ -71,7 +71,7 @@
 					<%= bundle.getString("challenge.hint.description") %>
 					<br />
 					<br />
-					<div>SELECT * FROM customers WHERE customerId =&quot;<a id="userContent"></a>&quot;;</div>
+					<div>SELECT * FROM customers WHERE customerId = '<a id="userContent"></a>'</div>
 					<br />
 					<br />
 				</div>


### PR DESCRIPTION
The SQL query was presented with quotes (") surrounding the user-supplied parameter, while it
was in fact apostrophes ('), as implied in the introduction and stated in the
text hint.

I also removed the trailing ';' which is not present in the source code.