### PR TITLE
Update targetSdkVersion to atleast >= 25.

### DIFF
--- a/src/MobileShepherd/PoorAuthentication/app/src/main/AndroidManifest.xml
+++ b/src/MobileShepherd/PoorAuthentication/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
     <uses-sdk
         android:minSdkVersion="14"
-        android:targetSdkVersion="20" />
+        android:targetSdkVersion="20" /> <! Should we not update this SdkVersion to atleast >=25 >
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />


### PR DESCRIPTION
minSdkVersion can be as low as 14, because certain exploits are possible only in those sdk versions but the target SdkVersion can be kept updated, right?