### PR TITLE
#470 update javax.mail to 1.4.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 		<dependency>
 			<groupId>javax.mail</groupId>
 			<artifactId>mail</artifactId>
-			<version>1.4</version>
+			<version>1.4.7</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.mongodb/mongo-java-driver -->


### PR DESCRIPTION
Updated JavaMail version to reject non-email format input. Tested and verified that the cheat-sheet solution of `test'or''!='2@test.com` on SQL injection challenge 2 continues to work as expected.

(Mostly just testing how contribution works here.)