### PR TITLE
Docker: replacing localhost with '%'

### DIFF
--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -17,7 +17,7 @@ ARG DOCKER_NETWORK_NAME
 COPY target/coreSchema.sql /docker-entrypoint-initdb.d/coreSchema.sql
 COPY target/moduleSchemas.sql /docker-entrypoint-initdb.d/moduleSchemas.sql
 
-RUN sed -i 's/@'\''localhost'\''/@'\'''"$CONTAINER_TOMCAT"'.'"$DOCKER_NETWORK_NAME"''\''/g' /docker-entrypoint-initdb.d/moduleSchemas.sql
+RUN sed -i 's/@'\''localhost'\''/@'\'''%''\''/g' /docker-entrypoint-initdb.d/moduleSchemas.sql
 
 RUN mkdir -p /etc/mysql/conf.d \
 	&& { \


### PR DESCRIPTION
Closes issue #502 

There's a bug preventing access to the mysql database for the SQLi lessons in a docker install.  The problem is that the mysql database requires connections from the tomcat container to match a predefined hostname, but this doesn't work consistently on all systems.  Instead, the mysql container will allow connections from any other container for improved portability.