### PR TITLE
CSRF Challenge 7: Updated challenge text's CSRF-token parameter name 

### DIFF
--- a/src/main/webapp/challenges/7d79ea2b2a82543d480a63e55ebb8fef3209c5d648b54d1276813cd072815df3.jsp
+++ b/src/main/webapp/challenges/7d79ea2b2a82543d480a63e55ebb8fef3209c5d648b54d1276813cd072815df3.jsp
@@ -87,7 +87,7 @@ if (request.getSession() != null)
 				<br/>
 				<a> POST /user/csrfchallengeseven/plusplus</a>
 				<br/>
-				<%= bundle.getString("challenge.withTheseParameters") %> <a>userId = <%= bundle.getString("challenge.userIdExample") %></a> & <a>csrf = <%= bundle.getString("challenge.yourCsrfTokenCamelCase") %></a>
+				<%= bundle.getString("challenge.withTheseParameters") %> <a>userId = <%= bundle.getString("challenge.userIdExample") %></a> & <a>csrfToken = <%= bundle.getString("challenge.yourCsrfTokenCamelCase") %></a>
 				<br/>
 				<br/>
 				<%= bundle.getString("challenge.whereIdIsUserBeenIncremented.1") %> <%= bundle.getString("challenge.userIdExample") %><%= bundle.getString("challenge.whereIdIsUserBeenIncremented.2") %> <%=bundle.getString("challenge.yourIdIs") %> <%= userId %> <%= bundle.getString("challenge.yourIdIs.1") %>


### PR DESCRIPTION
Updated a faulty challenge text which has confused our students. 

Changed the challenge text's POST parameter from csrf to csrfToken, which is what is actually validated on the server.
