### PR TITLE
Specifying Java 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can download Security Shepherd VM's or Manual Installation Packs from [GitHu
 #### Initial Setup
 ```console
 # Install pre-reqs
-sudo apt install git maven docker docker-compose default-jdk
+sudo apt install git maven docker docker-compose openjdk-8-jdk
 
 # Clone the github repository
 git clone https://github.com/OWASP/SecurityShepherd.git


### PR DESCRIPTION
Java 8 is required when spinning up Shepherd with docker as you need to build the war before running docker-compose. This change specifies that Java 8 is required. closes #595