### PR TITLE
fix for timezone setting in .env (#707)

### DIFF
--- a/.env
+++ b/.env
@@ -29,6 +29,8 @@ KEY_ALG=RSA
 DNAME=cn=OwaspShepherd,ou=SecurityShepherd,o=OWASP,L=BaileÁthaCliath,ST=Laighin,C=IE
 STORE_TYPE=pkcs12
 
+TZ=Europe/Dublin
+
 HTTP_PORT=80
 HTTPS_PORT=443
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,6 @@ RUN adduser --system --group ${RUN_USER} --home ${CATALINA_HOME}
 RUN chown -R ${RUN_USER}:${RUN_GROUP} $CATALINA_HOME
 USER ${RUN_USER}
 
-ENV CATALINA_OPTS "-Duser.timezone=Europe/Dublin"
-
 RUN rm -rf /usr/local/tomcat/webapps/ROOT
 RUN patch /usr/local/tomcat/conf/server.xml /usr/local/tomcat/conf/serverxml.patch
 RUN patch /usr/local/tomcat/conf/web.xml /usr/local/tomcat/conf/webxml.patch


### PR DESCRIPTION
Addendum/fix to #707
Add timezone setting to `.env`, remove `CATALINA_OPTS` from `Dockerfile`.
Ensures that both the tomcat and the mariadb container use the same timezone.