### PR TITLE
fix: accept qualified alert XSS detection (fixes #779)

### DIFF
--- a/src/main/java/utils/FindXSS.java
+++ b/src/main/java/utils/FindXSS.java
@@ -438,7 +438,7 @@ public class FindXSS {
           for (int i = 0; i < javascriptTriggers.length && !xssDetected; i++) {
             String javascriptTriggerValue = element.attr(javascriptTriggers[i]);
             if (!javascriptTriggerValue.isEmpty()) {
-              if (javascriptTriggerValue.startsWith("alert")) {
+              if (javascriptTriggerValue.contains("alert")) {
                 log.debug("Javascript Trigger XSS Detected");
                 xssDetected = true;
               }


### PR DESCRIPTION
## Problem

The XSS Lab 1 rejects valid XSS payloads where `alert()` is called through a qualifier 
like `window.alert()`.

Reported in #779 by @jmanico with payload:
`<img src="https://placehold.co/600x400" onload="window.alert('test');" />`


## Root cause

In `FindXSS.java` line 441, Stage Three (event handler detection) used 
`startsWith("alert")` to validate the attribute value. When the payload 
is `onload="window.alert('test')"`, the extracted value starts with 
`window`, not `alert`, so detection fails.


## Fix

Changed `startsWith("alert")` to `contains("alert")` on line 441, 
consistent with Stage One (line 387) which already uses `contains()` 
for `<script>` tag detection.

## Testing

Manually tested on local deployment:
- `<img src="https://placehold.co/600x400" onload="window.alert('test');" />` → now correctly detected
- `<script>alert('xss')</script>` → still correctly filtered by challenge


## Screenshots

### Before fix

<img width="719" height="568" alt="image" src="https://github.com/user-attachments/assets/83e3c923-a0c0-403f-a07b-66ca2929f1bd" />


### After fix

<img width="733" height="385" alt="image" src="https://github.com/user-attachments/assets/da2fcda1-9135-43fe-9769-31232b55f478" />
