### PR TITLE
style: format FindXSS.java with Google Java Format

### DIFF
--- a/src/main/java/utils/FindXSS.java
+++ b/src/main/java/utils/FindXSS.java
@@ -35,6 +35,7 @@ import org.w3c.tidy.Tidy;
 public class FindXSS {
 
   private static final Logger log = LogManager.getLogger(FindXSS.class);
+
   /**
    * Method used to detect valid java script in a user submission. Specifically the presence of a
    * script that will execute an alert command. Script tag, URI java script and java script triggers


### PR DESCRIPTION
Fix build failures by applying Google Java Format to FindXSS.java. Adds required blank line after logger declaration per formatting standards.