### PR TITLE
docs: add AGENTS.md for AI coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,81 @@
+# AGENTS.md
+
+Instructions for AI coding agents working on this repository.
+
+## Project overview
+
+OWASP Security Shepherd is a web and mobile application security training platform. The web app is a Java servlet application built with Maven, deployed as a WAR on Tomcat. The mobile challenges are independent Android apps under `src/MobileShepherd/`.
+
+## Intentionally vulnerable code — DO NOT FIX
+
+The following paths contain **deliberately insecure code** used for security training. Do not fix, refactor, or flag security vulnerabilities in these files:
+
+- `src/main/java/servlets/module/lesson/` — lesson servlets with intentional vulnerabilities
+- `src/main/java/servlets/module/challenge/` — challenge servlets with intentional vulnerabilities
+- `src/MobileShepherd/` — mobile challenge apps with intentional vulnerabilities
+
+Security improvements should only be made to the **platform infrastructure** (authentication, session management, admin functions, DB layer, etc.), never to the training content.
+
+## Code style
+
+All Java code MUST be formatted with [Google Java Format](https://github.com/google/google-java-format). CI enforces this via `axel-op/googlejavaformat-action` and will reject unformatted code.
+
+Before committing Java changes, run:
+
+```bash
+google-java-format --replace <changed-files>
+```
+
+## Java version
+
+The project targets **Java 8**. All code must compile against Java 8, even though CI uses Java 24 for linting. Do not use Java 9+ APIs or language features.
+
+## Build and test
+
+```bash
+mvn -Pdocker clean install -DskipTests -B   # build WAR with Docker profile (required before docker compose)
+docker compose build                          # build Docker images
+mvn test -B                                   # unit tests
+mvn verify -DskipUTs=true -DmongoDocker -B   # integration tests (requires MySQL + MongoDB)
+```
+
+The `-Pdocker` profile must run before `docker compose build` — it generates SQL scripts, MongoDB init scripts, and TLS keystores.
+
+## Git workflow
+
+- Never commit directly to `master` or `dev`
+- Branch naming: `dev#{issueNumber}` (e.g. `dev#536`)
+- PRs always target `dev`, not `master`
+
+## Project structure
+
+- `src/main/java/` — web app source (servlets, DB layer, utilities)
+- `src/main/resources/` — config and challenge properties files
+- `src/test/java/` — unit tests
+- `src/it/java/` — integration tests (require running DB containers)
+- `src/MobileShepherd/` — independent Android apps (Gradle-based, not part of Maven build)
+
+## Database
+
+- MySQL/MariaDB for the core app and SQL-based challenges
+- MongoDB for NoSQL challenges
+- Each challenge uses isolated DB credentials scoped to its own schema — do not consolidate challenge DB users
+- Encoding must be `utf8mb4` (not `utf8`) for full Unicode support
+- Password hashing uses Argon2 (requires `libargon2` native library)
+
+## Agent behaviors
+
+### Bug fixes must include tests
+
+When fixing a bug, always write a test that reproduces the bug first, then apply the fix. The test should fail without the fix and pass with it.
+
+### Keep documentation up to date
+
+When making significant changes (new features, architectural changes, build/config changes, new dependencies), check whether these files need updating:
+
+- `AGENTS.md` (this file)
+- `CONTRIBUTING.md`
+- `README.md`
+- Files in `docs/`
+
+Do not scan these files on every change — only review and update them when your changes would make their content inaccurate.


### PR DESCRIPTION
## Summary
- Adds `AGENTS.md` with project conventions and behavioral guidelines for LLM coding agents
- Prevents agents from "fixing" intentionally vulnerable challenge/lesson code
- Documents Google Java Format requirement, Java 8 target, build commands, git workflow, and DB constraints
- Instructs agents to write tests with every bug fix and keep docs up to date when making significant changes

## Test plan
- [x] Verify AGENTS.md renders correctly on GitHub
- [x] No code changes — documentation only