### PR TITLE
fix: return core DB connections to pool from Getter (stacked on #816)

### DIFF
--- a/docs/database-configuration.md
+++ b/docs/database-configuration.md
@@ -95,9 +95,9 @@ databaseUsername=root
 databasePassword=your_password
 
 # HikariCP Pool Settings (optional - defaults shown)
-pool.maximumPoolSize=10
-pool.minimumIdle=2
-pool.connectionTimeout=30000
+pool.maximumPoolSize=20
+pool.minimumIdle=5
+pool.connectionTimeout=5000
 pool.idleTimeout=600000
 pool.maxLifetime=1800000
 pool.poolName=SecurityShepherdPool
@@ -107,9 +107,9 @@ pool.poolName=SecurityShepherdPool
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `pool.maximumPoolSize` | 10 | Maximum number of connections in the pool |
-| `pool.minimumIdle` | 2 | Minimum number of idle connections to maintain |
-| `pool.connectionTimeout` | 30000 | Maximum time (ms) to wait for a connection |
+| `pool.maximumPoolSize` | 20 | Maximum number of connections in the pool |
+| `pool.minimumIdle` | 5 | Minimum number of idle connections to maintain |
+| `pool.connectionTimeout` | 5000 | Maximum time (ms) to wait for a connection |
 | `pool.idleTimeout` | 600000 | Maximum time (ms) a connection can be idle |
 | `pool.maxLifetime` | 1800000 | Maximum lifetime (ms) of a connection |
 | `pool.leakDetectionThreshold` | 60000 | Logs a warning if a connection is held longer than this (ms). Set to 0 to disable |

--- a/src/it/java/dbProcs/GetterCorePoolLeakIT.java
+++ b/src/it/java/dbProcs/GetterCorePoolLeakIT.java
@@ -1,0 +1,71 @@
+package dbProcs;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import testUtils.TestProperties;
+
+/**
+ * Verifies that high-frequency Getter core DB calls return connections to the Hikari pool (no
+ * unbounded growth in active connections).
+ */
+public class GetterCorePoolLeakIT {
+
+  private static final Logger log = LogManager.getLogger(GetterCorePoolLeakIT.class);
+  private static boolean databaseAvailable = false;
+  private static final String applicationRoot = "";
+
+  /** Must stay within configured core pool max (see database.properties / ConnectionPool). */
+  private static final int MAX_ALLOWED_ACTIVE = 32;
+
+  @BeforeAll
+  public static void setup() throws IOException, SQLException {
+    TestProperties.setTestPropertiesFileDirectory(log);
+    TestProperties.createMysqlResource();
+    TestProperties.executeSql(log);
+    try {
+      ConnectionPool.initialize();
+      Getter.getClassCount(applicationRoot);
+      databaseAvailable = ConnectionPool.isInitialized();
+    } catch (Exception e) {
+      log.warn("Database not available for GetterCorePoolLeakIT: {}", e.getMessage());
+      databaseAvailable = false;
+    }
+  }
+
+  @AfterAll
+  public static void cleanup() {
+    ConnectionPool.shutdown();
+  }
+
+  private void requireDatabase() {
+    assumeTrue(databaseAvailable, "Database not available");
+  }
+
+  @Test
+  public void repeatedAuthUserDoesNotExhaustCorePool() {
+    requireDatabase();
+    int baseline = ConnectionPool.getCoreActiveConnections();
+    assertTrue(baseline >= 0);
+
+    for (int i = 0; i < 500; i++) {
+      Getter.authUser(applicationRoot, "nonexistent_pool_leak_user_" + i, "wrongpassword");
+    }
+
+    int active = ConnectionPool.getCoreActiveConnections();
+    log.debug(
+        "GetterCorePoolLeakIT: baseline active={}, after 500 authUser calls active={}",
+        baseline,
+        active);
+    assertTrue(
+        active <= MAX_ALLOWED_ACTIVE,
+        "Core pool active connections should stay bounded; got " + active);
+  }
+}

--- a/src/it/java/servlets/SetupIT.java
+++ b/src/it/java/servlets/SetupIT.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 import dbProcs.ConnectionPool;
 import dbProcs.Constants;
@@ -159,20 +160,26 @@ public class SetupIT {
     TestProperties.createMysqlResource();
     TestProperties.executeSql(log);
 
+    boolean poolReady = false;
     try {
       ConnectionPool.initialize();
+      poolReady = ConnectionPool.isInitialized();
     } catch (Exception e) {
       log.warn("Pool init issue: " + e.getMessage());
     }
+    assumeTrue(poolReady);
 
-    Setup.resetInstalledCache();
+    try {
+      Setup.resetInstalledCache();
 
-    boolean first = Setup.isInstalled();
-    boolean second = Setup.isInstalled();
+      boolean first = Setup.isInstalled();
+      boolean second = Setup.isInstalled();
 
-    assertEquals(first, second);
-
-    ConnectionPool.shutdown();
+      assertTrue("isInstalled should return true with a running database", first);
+      assertEquals(first, second);
+    } finally {
+      ConnectionPool.shutdown();
+    }
   }
 
   @Test
@@ -181,20 +188,26 @@ public class SetupIT {
     TestProperties.createMysqlResource();
     TestProperties.executeSql(log);
 
+    boolean poolReady = false;
     try {
       ConnectionPool.initialize();
+      poolReady = ConnectionPool.isInitialized();
     } catch (Exception e) {
       log.warn("Pool init issue: " + e.getMessage());
     }
+    assumeTrue(poolReady);
 
-    Setup.resetInstalledCache();
-    boolean first = Setup.isInstalled();
+    try {
+      Setup.resetInstalledCache();
+      boolean first = Setup.isInstalled();
 
-    Setup.resetInstalledCache();
-    boolean second = Setup.isInstalled();
+      Setup.resetInstalledCache();
+      boolean second = Setup.isInstalled();
 
-    assertEquals(first, second);
-
-    ConnectionPool.shutdown();
+      assertTrue("isInstalled should return true with a running database", first);
+      assertEquals(first, second);
+    } finally {
+      ConnectionPool.shutdown();
+    }
   }
 }

--- a/src/it/java/servlets/SetupIT.java
+++ b/src/it/java/servlets/SetupIT.java
@@ -1,13 +1,16 @@
 package servlets;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import dbProcs.ConnectionPool;
 import dbProcs.Constants;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
 import javax.servlet.ServletException;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
@@ -148,29 +151,50 @@ public class SetupIT {
       log.fatal(message);
       fail(message);
     }
-    /*
-     * request.getSession().setAttribute("lang", lang);
-     *
-     * request.addParameter("dbhost", "localhost"); request.addParameter("dbport",
-     * "3306"); request.addParameter("dbuser", "root");
-     * request.addParameter("dbpass", ""); request.addParameter("dbauth", authData);
-     *
-     * log.debug("Running doPost"); try { servlet.doPost(request, response); } catch
-     * (ServletException | IOException e) { e.printStackTrace();
-     * log.fatal(e.toString()); fail(e.toString()); }
-     * log.debug("doPost successful, reading response");
-     *
-     * if(response.getStatus() != expectedResponseCode) { String
-     * message="Login Servlet Returned " + response.getStatus() +
-     * " Code. 302 Expected"; log.fatal(message); fail(message); } String location =
-     * ""; try { location = response.getHeader("Location"); } catch
-     * (NullPointerException e) { String message =
-     * "Got invalid location from posting setup request: " + e.toString();
-     * log.fatal(message); fail(message); }
-     *
-     * if (!location.endsWith("login.jsp")) {
-     * fail("Setup not Redirecting to login.jsp."); }
-     */
+  }
 
+  @Test
+  public void isInstalled_cachesResult() throws IOException, SQLException {
+    TestProperties.setTestPropertiesFileDirectory(log);
+    TestProperties.createMysqlResource();
+    TestProperties.executeSql(log);
+
+    try {
+      ConnectionPool.initialize();
+    } catch (Exception e) {
+      log.warn("Pool init issue: " + e.getMessage());
+    }
+
+    Setup.resetInstalledCache();
+
+    boolean first = Setup.isInstalled();
+    boolean second = Setup.isInstalled();
+
+    assertEquals(first, second);
+
+    ConnectionPool.shutdown();
+  }
+
+  @Test
+  public void resetInstalledCache_allowsReevaluation() throws IOException, SQLException {
+    TestProperties.setTestPropertiesFileDirectory(log);
+    TestProperties.createMysqlResource();
+    TestProperties.executeSql(log);
+
+    try {
+      ConnectionPool.initialize();
+    } catch (Exception e) {
+      log.warn("Pool init issue: " + e.getMessage());
+    }
+
+    Setup.resetInstalledCache();
+    boolean first = Setup.isInstalled();
+
+    Setup.resetInstalledCache();
+    boolean second = Setup.isInstalled();
+
+    assertEquals(first, second);
+
+    ConnectionPool.shutdown();
   }
 }

--- a/src/main/java/dbProcs/ConnectionPool.java
+++ b/src/main/java/dbProcs/ConnectionPool.java
@@ -384,6 +384,19 @@ public class ConnectionPool {
         coreDataSource.getHikariPoolMXBean().getThreadsAwaitingConnection());
   }
 
+  /**
+   * Returns the number of connections currently checked out from the core pool. Intended for
+   * integration tests that verify connections are returned after Getter/Setter operations.
+   *
+   * @return active connection count, or -1 if the pool is not initialized
+   */
+  public static int getCoreActiveConnections() {
+    if (coreDataSource == null || coreDataSource.isClosed()) {
+      return -1;
+    }
+    return coreDataSource.getHikariPoolMXBean().getActiveConnections();
+  }
+
   /** Helper method to get an integer property with a default value. */
   private static int getIntProperty(Properties prop, String key, int defaultValue) {
     String value = prop.getProperty(key);

--- a/src/main/java/dbProcs/ConnectionPool.java
+++ b/src/main/java/dbProcs/ConnectionPool.java
@@ -41,9 +41,10 @@ public class ConnectionPool {
       new ConcurrentHashMap<>();
 
   // Default pool configuration values (used by core pool)
-  private static final int DEFAULT_MAX_POOL_SIZE = 10;
-  private static final int DEFAULT_MIN_IDLE = 2;
-  private static final long DEFAULT_CONNECTION_TIMEOUT = 30000; // 30 seconds
+  private static final int DEFAULT_MAX_POOL_SIZE = 20;
+  private static final int DEFAULT_MIN_IDLE = 5;
+  private static final long DEFAULT_CONNECTION_TIMEOUT =
+      5000; // 5 seconds — fail fast under overload
   private static final long DEFAULT_IDLE_TIMEOUT = 600000; // 10 minutes
   private static final long DEFAULT_MAX_LIFETIME = 1800000; // 30 minutes
   private static final long DEFAULT_LEAK_DETECTION_THRESHOLD = 60000; // 60 seconds

--- a/src/main/java/dbProcs/Getter.java
+++ b/src/main/java/dbProcs/Getter.java
@@ -216,9 +216,6 @@ public class Getter {
               log.debug("userBadLoginReset executed!");
             }
           }
-          // User has logged in, or a Authentication Bypass was detected... You never
-          // know! Better safe than sorry
-          // TODO: will this close the db connection if we return here?
           return result;
         } else {
           // Hash did not match

--- a/src/main/java/dbProcs/Getter.java
+++ b/src/main/java/dbProcs/Getter.java
@@ -79,159 +79,157 @@ public class Getter {
     boolean userFound = false;
     boolean userVerified = false;
 
-    Connection conn;
-    try {
-      conn = Database.getCoreConnection(ApplicationRoot);
-    } catch (SQLException e) {
-      log.fatal("Could create get core connection: " + e.toString());
-      throw new RuntimeException(e);
-    }
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
-    // See if user Exists
-    PreparedStatement prestmt;
-    CallableStatement callstmt;
-    try {
-      prestmt =
-          conn.prepareStatement(
-              "SELECT userId, userName, userPass, userRole, badLoginCount, tempPassword, classId,"
-                  + " suspendedUntil, loginType, tempUsername FROM `users` WHERE userName = ?");
-    } catch (SQLException e) {
-      log.fatal("Could create call statement: " + e.toString());
-      throw new RuntimeException(e);
-    }
+      // See if user Exists
+      PreparedStatement prestmt;
+      CallableStatement callstmt;
+      try {
+        prestmt =
+            conn.prepareStatement(
+                "SELECT userId, userName, userPass, userRole, badLoginCount, tempPassword, classId,"
+                    + " suspendedUntil, loginType, tempUsername FROM `users` WHERE userName = ?");
+      } catch (SQLException e) {
+        log.fatal("Could create call statement: " + e.toString());
+        throw new RuntimeException(e);
+      }
 
-    log.debug("Gathering results from query");
-    ResultSet userResult;
-    try {
-      prestmt.setString(1, userName);
-      userResult = prestmt.executeQuery();
-    } catch (SQLException e) {
-      log.fatal("Could not execute db query: " + e.toString());
-      throw new RuntimeException(e);
-    }
+      log.debug("Gathering results from query");
+      ResultSet userResult;
+      try {
+        prestmt.setString(1, userName);
+        userResult = prestmt.executeQuery();
+      } catch (SQLException e) {
+        log.fatal("Could not execute db query: " + e.toString());
+        throw new RuntimeException(e);
+      }
 
-    log.debug("Opening Result Set from query");
+      log.debug("Opening Result Set from query");
 
-    try {
-      if (userResult.next()) {
-        log.debug(
-            "User Found"); // User found if a row is in the database, this line will not work if the
-        // result
-        // set is empty
-        userFound = true;
-      } else {
+      try {
+        if (userResult.next()) {
+          log.debug(
+              "User Found"); // User found if a row is in the database, this line will not work if
+                             // the
+          // result
+          // set is empty
+          userFound = true;
+        } else {
+          log.debug("User did not exist");
+          userFound = false;
+        }
+      } catch (SQLException e) {
         log.debug("User did not exist");
         userFound = false;
       }
-    } catch (SQLException e) {
-      log.debug("User did not exist");
-      userFound = false;
-    }
 
-    if (userFound) {
-      // Authenticate User
-      Argon2 argon2 = Argon2Factory.create();
+      if (userFound) {
+        // Authenticate User
+        Argon2 argon2 = Argon2Factory.create();
 
-      log.debug("Getting password hash");
-      String dbHash;
-      try {
-        dbHash = userResult.getString(3);
-        log.debug("Verifying hash");
-
-        userVerified = argon2.verify(dbHash, password.toCharArray());
-
-      } catch (SQLException e) {
-        log.fatal("Could not retrieve password hash from db: " + e.toString());
-        result = null;
-        userVerified = false;
-        throw new RuntimeException(e);
-        // TODO: We should throw a checked exception here instead
-      }
-
-      if (userVerified) {
-        // Hash matches
-        log.debug("Hash matches");
-
-        result = new String[6];
-
-        int badLoginCount;
-        String loginType = new String();
-
-        Timestamp suspendedUntil;
-
+        log.debug("Getting password hash");
+        String dbHash;
         try {
-          result[0] = userResult.getString(1);
-          result[1] = userResult.getString(2); // userName
-          result[2] = userResult.getString(4); // role
-          badLoginCount = userResult.getInt(5);
-          result[3] = Boolean.toString(userResult.getBoolean(6));
-          result[4] = userResult.getString(7); // classId
-          suspendedUntil = userResult.getTimestamp(8);
-          loginType = userResult.getString(9);
-          result[5] = Boolean.toString(userResult.getBoolean(10));
+          dbHash = userResult.getString(3);
+          log.debug("Verifying hash");
+
+          userVerified = argon2.verify(dbHash, password.toCharArray());
+
         } catch (SQLException e) {
-
-          log.fatal("Could not retrieve auth data from db: " + e.toString());
+          log.fatal("Could not retrieve password hash from db: " + e.toString());
+          result = null;
+          userVerified = false;
           throw new RuntimeException(e);
+          // TODO: We should throw a checked exception here instead
         }
 
-        if (!loginType.equals("login")) {
-          // Login type must be "login" and not "saml" if password login is to be allowed
-          log.debug("User is SSO user, can't login with password!");
-          result = null;
-          return result;
-        }
+        if (userVerified) {
+          // Hash matches
+          log.debug("Hash matches");
 
-        // Get current system time
-        Timestamp currentTime = new Timestamp(System.currentTimeMillis());
+          result = new String[6];
 
-        if (suspendedUntil.after(currentTime)) {
-          // User is suspended
-          result = null;
-          return result;
-        }
+          int badLoginCount;
+          String loginType = new String();
 
-        if (!result[1].equalsIgnoreCase(
-            userName)) // If somehow this functionality has been compromised to sign
-        // in as
-        // other users, this will limit the expoitability. But the method is
-        // sql injection safe, so it should be ok
-        {
-          log.fatal(
-              "User Name used ("
-                  + userName
-                  + ") and User Name retrieved ("
-                  + result[1]
-                  + ") were not the Same. Nulling Result");
-          result = null;
-        } else {
-          log.debug("User '" + userName + "' has logged in");
-          // Before finishing, check if user had a badlogin history, if so, Clear it
-          if (badLoginCount > 0) {
-            log.debug("Clearing Bad Login History");
-            try {
-              callstmt = conn.prepareCall("call userBadLoginReset(?)");
-              callstmt.setString(1, result[0]);
-              callstmt.execute();
-            } catch (SQLException e) {
-              log.fatal("Could not reset bad login count: " + e.toString());
-              throw new RuntimeException(e);
-            }
+          Timestamp suspendedUntil;
 
-            log.debug("userBadLoginReset executed!");
+          try {
+            result[0] = userResult.getString(1);
+            result[1] = userResult.getString(2); // userName
+            result[2] = userResult.getString(4); // role
+            badLoginCount = userResult.getInt(5);
+            result[3] = Boolean.toString(userResult.getBoolean(6));
+            result[4] = userResult.getString(7); // classId
+            suspendedUntil = userResult.getTimestamp(8);
+            loginType = userResult.getString(9);
+            result[5] = Boolean.toString(userResult.getBoolean(10));
+          } catch (SQLException e) {
+
+            log.fatal("Could not retrieve auth data from db: " + e.toString());
+            throw new RuntimeException(e);
           }
-        }
-        // User has logged in, or a Authentication Bypass was detected... You never
-        // know! Better safe than sorry
-        // TODO: will this close the db connection if we return here?
-        return result;
-      } else {
-        // Hash did not match
-        log.debug("Hash did not match, authentication failed");
-      }
-    }
 
-    Database.closeConnection(conn);
+          if (!loginType.equals("login")) {
+            // Login type must be "login" and not "saml" if password login is to be allowed
+            log.debug("User is SSO user, can't login with password!");
+            result = null;
+            return result;
+          }
+
+          // Get current system time
+          Timestamp currentTime = new Timestamp(System.currentTimeMillis());
+
+          if (suspendedUntil.after(currentTime)) {
+            // User is suspended
+            result = null;
+            return result;
+          }
+
+          if (!result[1].equalsIgnoreCase(
+              userName)) // If somehow this functionality has been compromised to sign
+          // in as
+          // other users, this will limit the expoitability. But the method is
+          // sql injection safe, so it should be ok
+          {
+            log.fatal(
+                "User Name used ("
+                    + userName
+                    + ") and User Name retrieved ("
+                    + result[1]
+                    + ") were not the Same. Nulling Result");
+            result = null;
+          } else {
+            log.debug("User '" + userName + "' has logged in");
+            // Before finishing, check if user had a badlogin history, if so, Clear it
+            if (badLoginCount > 0) {
+              log.debug("Clearing Bad Login History");
+              try {
+                callstmt = conn.prepareCall("call userBadLoginReset(?)");
+                callstmt.setString(1, result[0]);
+                callstmt.execute();
+              } catch (SQLException e) {
+                log.fatal("Could not reset bad login count: " + e.toString());
+                throw new RuntimeException(e);
+              }
+
+              log.debug("userBadLoginReset executed!");
+            }
+          }
+          // User has logged in, or a Authentication Bypass was detected... You never
+          // know! Better safe than sorry
+          // TODO: will this close the db connection if we return here?
+          return result;
+        } else {
+          // Hash did not match
+          log.debug("Hash did not match, authentication failed");
+        }
+      }
+
+    } catch (SQLException e) {
+      log.fatal("authUser failed: " + e.toString());
+      throw new RuntimeException(e);
+    }
     log.debug("$$$ End authUser $$$");
     return result;
   }
@@ -266,83 +264,182 @@ public class Getter {
 
     boolean isTempUsername = false;
 
-    Connection conn;
-    try {
-      conn = Database.getCoreConnection(ApplicationRoot);
-    } catch (SQLException e) {
-      log.fatal("Could create get core connection: " + e.toString());
-      throw new RuntimeException(e);
-    }
-    // See if user Exists
-    PreparedStatement prestmt;
-    try {
-      prestmt =
-          conn.prepareStatement(
-              "SELECT userId, userName, userPass, badLoginCount, tempPassword, classId,"
-                  + " suspendedUntil, loginType FROM `users` WHERE ssoName = ? AND"
-                  + " loginType='saml'");
-    } catch (SQLException e) {
-      log.fatal("Could create call statement: " + e.toString());
-      throw new RuntimeException(e);
-    }
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+      // See if user Exists
+      PreparedStatement prestmt;
+      try {
+        prestmt =
+            conn.prepareStatement(
+                "SELECT userId, userName, userPass, badLoginCount, tempPassword, classId,"
+                    + " suspendedUntil, loginType FROM `users` WHERE ssoName = ? AND"
+                    + " loginType='saml'");
+      } catch (SQLException e) {
+        log.fatal("Could create call statement: " + e.toString());
+        throw new RuntimeException(e);
+      }
 
-    log.debug("Gathering userFind ResultSet");
-    ResultSet userResult;
-    try {
-      prestmt.setString(1, ssoName);
-      log.debug("Executing query");
-      userResult = prestmt.executeQuery();
-    } catch (SQLException e) {
-      log.fatal("Could not execute db query: " + e.toString());
-      throw new RuntimeException(e);
-    }
+      log.debug("Gathering userFind ResultSet");
+      ResultSet userResult;
+      try {
+        prestmt.setString(1, ssoName);
+        log.debug("Executing query");
+        userResult = prestmt.executeQuery();
+      } catch (SQLException e) {
+        log.fatal("Could not execute db query: " + e.toString());
+        throw new RuntimeException(e);
+      }
 
-    log.debug("Opening Result Set from userResult");
+      log.debug("Opening Result Set from userResult");
 
-    try {
-      if (userResult.next()) {
-        // User found if a row is in the database
-        userFound = true;
-        log.debug("User Found");
-      } else {
+      try {
+        if (userResult.next()) {
+          // User found if a row is in the database
+          userFound = true;
+          log.debug("User Found");
+        } else {
+          userFound = false;
+        }
+
+      } catch (SQLException e) {
+        log.debug("User did not exist");
         userFound = false;
       }
 
-    } catch (SQLException e) {
-      log.debug("User did not exist");
-      userFound = false;
-    }
+      if (!userFound) {
+        // User wasn't found, enroll them in database
 
-    if (!userFound) {
-      // User wasn't found, enroll them in database
+        boolean userCreated = false;
 
-      boolean userCreated = false;
+        log.debug("User did not exist, create it from SSO data");
 
-      log.debug("User did not exist, create it from SSO data");
+        try {
 
+          if (defaultClass.isEmpty()) {
+            log.debug("Adding player to database, with null classId");
+            newUsername = Setter.userCreateSSO(ApplicationRoot, null, userName, ssoName, userRole);
+          } else // defaultClass is not empty, so It must be set to a class!
+          {
+            log.debug("Adding player to database, to class " + defaultClass);
+            newUsername =
+                Setter.userCreateSSO(ApplicationRoot, defaultClass, userName, ssoName, userRole);
+          }
+
+          if (newUsername == null) {
+            userCreated = false;
+          } else {
+            userCreated = true;
+          }
+
+          userName = newUsername;
+
+        } catch (SQLException e) {
+          String message =
+              "Could not create user "
+                  + userName
+                  + " with ssoName "
+                  + ssoName
+                  + " via SSO: "
+                  + e.toString();
+          log.fatal(message);
+          throw new RuntimeException(message);
+        }
+
+        if (!userCreated) {
+          String message =
+              "Could not create user " + userName + " with ssoName " + ssoName + " via SSO";
+          log.fatal(message);
+          throw new RuntimeException(message);
+        }
+
+        log.debug("User created");
+
+      } else {
+
+        Timestamp suspendedUntil;
+
+        log.debug("Getting suspension data");
+
+        try {
+          suspendedUntil = userResult.getTimestamp(7);
+        } catch (SQLException e) {
+          log.fatal(
+              "Could not find suspension information from ssoName: "
+                  + ssoName
+                  + ": "
+                  + e.toString());
+          throw new RuntimeException(e);
+        }
+
+        // Get current system time
+        Timestamp currentTime = new Timestamp(System.currentTimeMillis());
+
+        if (suspendedUntil.after(currentTime)) {
+          // User is suspended
+          log.debug("User is suspended");
+
+          result = null;
+          return result;
+        }
+      }
+
+      // Find the generated userID and username by asking the database
       try {
-
-        if (defaultClass.isEmpty()) {
-          log.debug("Adding player to database, with null classId");
-          newUsername = Setter.userCreateSSO(ApplicationRoot, null, userName, ssoName, userRole);
-        } else // defaultClass is not empty, so It must be set to a class!
-        {
-          log.debug("Adding player to database, to class " + defaultClass);
-          newUsername =
-              Setter.userCreateSSO(ApplicationRoot, defaultClass, userName, ssoName, userRole);
-        }
-
-        if (newUsername == null) {
-          userCreated = false;
-        } else {
-          userCreated = true;
-        }
-
-        userName = newUsername;
+        prestmt =
+            conn.prepareStatement(
+                "SELECT userId, userName, classID, tempUsername FROM `users` WHERE ssoName = ? AND"
+                    + " loginType='saml'");
 
       } catch (SQLException e) {
+        log.fatal("Could create call statement: " + e.toString());
+        throw new RuntimeException(e);
+      }
+
+      log.debug("Gathering userResult ResultSet");
+
+      try {
+        prestmt.setString(1, ssoName);
+        log.debug("Executing query");
+        userResult = prestmt.executeQuery();
+      } catch (SQLException e) {
+        log.fatal("Could not execute db query: " + e.toString());
+        throw new RuntimeException(e);
+      }
+
+      log.debug("Opening user list result set");
+
+      try {
+        if (userResult.next()) {
+          userFound = true;
+          log.debug(
+              "User Found"); // User found if a row is in the database, this line will not work if
+                             // the
+          // result
+          // set is empty
+        } else {
+          userFound = false;
+        }
+
+      } catch (SQLException e) {
+        log.debug("User did not exist");
+        userFound = false;
+      }
+
+      if (!userFound) {
+        // If user wasn't found at this stage something is quite wrong, so exit
+        // forefully
+        String message = "User wasn't found after being added!";
+        log.fatal(message);
+        throw new RuntimeException(message);
+      }
+
+      try {
+        userID = userResult.getString(1);
+        userName = userResult.getString(2);
+        classId = userResult.getString(3); // classId
+        isTempUsername = userResult.getBoolean(4);
+      } catch (SQLException e) {
         String message =
-            "Could not create user "
+            "Could find userID for userName "
                 + userName
                 + " with ssoName "
                 + ssoName
@@ -352,119 +449,21 @@ public class Getter {
         throw new RuntimeException(message);
       }
 
-      if (!userCreated) {
-        String message =
-            "Could not create user " + userName + " with ssoName " + ssoName + " via SSO";
-        log.fatal(message);
-        throw new RuntimeException(message);
-      }
+      log.debug("User '" + userName + "' has logged in via SSO" + " with role " + userRole);
 
-      log.debug("User created");
+      result[0] = userID;
+      result[1] = userName; // userName
+      result[2] = userRole; // role
+      result[5] = "false"; // sso logins can't change password
+      result[4] = classId; // classId
+      result[5] = Boolean.toString(isTempUsername);
 
-    } else {
-
-      Timestamp suspendedUntil;
-
-      log.debug("Getting suspension data");
-
-      try {
-        suspendedUntil = userResult.getTimestamp(7);
-      } catch (SQLException e) {
-        log.fatal(
-            "Could not find suspension information from ssoName: " + ssoName + ": " + e.toString());
-        throw new RuntimeException(e);
-      }
-
-      // Get current system time
-      Timestamp currentTime = new Timestamp(System.currentTimeMillis());
-
-      if (suspendedUntil.after(currentTime)) {
-        // User is suspended
-        log.debug("User is suspended");
-
-        result = null;
-        return result;
-      }
-    }
-
-    // Find the generated userID and username by asking the database
-    try {
-      prestmt =
-          conn.prepareStatement(
-              "SELECT userId, userName, classID, tempUsername FROM `users` WHERE ssoName = ? AND"
-                  + " loginType='saml'");
-
+      log.debug("$$$ End authUser $$$");
+      return result;
     } catch (SQLException e) {
-      log.fatal("Could create call statement: " + e.toString());
+      log.fatal("authUserSSO failed: " + e.toString());
       throw new RuntimeException(e);
     }
-
-    log.debug("Gathering userResult ResultSet");
-
-    try {
-      prestmt.setString(1, ssoName);
-      log.debug("Executing query");
-      userResult = prestmt.executeQuery();
-    } catch (SQLException e) {
-      log.fatal("Could not execute db query: " + e.toString());
-      throw new RuntimeException(e);
-    }
-
-    log.debug("Opening user list result set");
-
-    try {
-      if (userResult.next()) {
-        userFound = true;
-        log.debug(
-            "User Found"); // User found if a row is in the database, this line will not work if the
-        // result
-        // set is empty
-      } else {
-        userFound = false;
-      }
-
-    } catch (SQLException e) {
-      log.debug("User did not exist");
-      userFound = false;
-    }
-
-    if (!userFound) {
-      // If user wasn't found at this stage something is quite wrong, so exit
-      // forefully
-      String message = "User wasn't found after being added!";
-      log.fatal(message);
-      throw new RuntimeException(message);
-    }
-
-    try {
-      userID = userResult.getString(1);
-      userName = userResult.getString(2);
-      classId = userResult.getString(3); // classId
-      isTempUsername = userResult.getBoolean(4);
-    } catch (SQLException e) {
-      String message =
-          "Could find userID for userName "
-              + userName
-              + " with ssoName "
-              + ssoName
-              + " via SSO: "
-              + e.toString();
-      log.fatal(message);
-      throw new RuntimeException(message);
-    }
-
-    log.debug("User '" + userName + "' has logged in via SSO" + " with role " + userRole);
-
-    result[0] = userID;
-    result[1] = userName; // userName
-    result[2] = userRole; // role
-    result[5] = "false"; // sso logins can't change password
-    result[4] = classId; // classId
-    result[5] = Boolean.toString(isTempUsername);
-
-    Database.closeConnection(conn);
-    log.debug("$$$ End authUser $$$");
-    return result;
   }
 
   /**
@@ -480,8 +479,7 @@ public class Getter {
     log.debug("*** Getter.checkPlayerResult ***");
 
     String result = null;
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       log.debug("Preparing userCheckResult call");
       CallableStatement callstmnt = conn.prepareCall("call userCheckResult(?, ?)");
@@ -491,8 +489,6 @@ public class Getter {
       ResultSet resultSet = callstmnt.executeQuery();
       resultSet.next();
       result = resultSet.getString(1);
-      Database.closeConnection(conn);
-
     } catch (SQLException e) {
       log.debug("userCheckResult Failure: " + e.toString());
       result = null;
@@ -511,8 +507,7 @@ public class Getter {
     log.debug("*** Getter.findPlayerById ***");
     boolean userFound = false;
     // Get connection
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       CallableStatement callstmt = conn.prepareCall("call playerFindById(?)");
       log.debug("Gathering playerFindById ResultSet");
@@ -524,8 +519,6 @@ public class Getter {
           "Player Found: "
               + userFind.getString(1)); // This line will not execute if player not found
       userFound = true;
-      Database.closeConnection(conn);
-
     } catch (SQLException e) {
       log.error("Player did not exist: " + e.toString());
       userFound = false;
@@ -546,8 +539,7 @@ public class Getter {
     log.debug("*** Getter.getAllModuleInfo ***");
     ArrayList<String[]> modules = new ArrayList<String[]>();
 
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       CallableStatement callstmt = conn.prepareCall("call moduleGetAll()");
       log.debug("Gathering moduleGetAll ResultSet");
@@ -564,8 +556,6 @@ public class Getter {
         modules.add(result);
       }
       log.debug("Returning Array list with " + i + " entries.");
-      Database.closeConnection(conn);
-
     } catch (SQLException e) {
       log.error("Could not execute query: " + e.toString());
     }
@@ -590,63 +580,63 @@ public class Getter {
     // Getting Translated Level Names
     ResourceBundle bundle = ResourceBundle.getBundle("i18n.moduleGenerics.moduleNames", lang);
     // Encoder to prevent XSS
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
-    CallableStatement callstmt = conn.prepareCall("call moduleAllInfo(?, ?)");
-    callstmt.setString(1, "challenge");
-    callstmt.setString(2, userId);
-    log.debug("Gathering moduleAllInfo ResultSet");
-    ResultSet challenges = callstmt.executeQuery();
-    log.debug("Opening Result Set from moduleAllInfo");
-    String challengeCategory = new String();
-    int rowNumber = 0; // Identifies the first row, ie the start of the list. This is slightly
-    // different output to every other row
-    while (challenges.next()) {
-      if (!challengeCategory.equalsIgnoreCase(challenges.getString(2))) {
-        challengeCategory = challenges.getString(2);
-        // log.debug("New Category Detected: " + challengeCategory);
-        if (rowNumber > 0) // output prepared for Every row after row 1
-        {
-          output +=
-              "</ul></li><li><a href='javascript:;' class='challengeHeader' >"
-                  + Encode.forHtml(bundle.getString("category." + challengeCategory))
-                  + "</a><ul class='challengeList' style='display: none;'>";
-        } else // output prepared for First row in entire challenge
-        {
-          output +=
-              "<li><a href='javascript:;' class='challengeHeader'>"
-                  + Encode.forHtml(bundle.getString("category." + challengeCategory))
-                  + "</a><ul class='challengeList' style='display: none;'>";
+      CallableStatement callstmt = conn.prepareCall("call moduleAllInfo(?, ?)");
+      callstmt.setString(1, "challenge");
+      callstmt.setString(2, userId);
+      log.debug("Gathering moduleAllInfo ResultSet");
+      ResultSet challenges = callstmt.executeQuery();
+      log.debug("Opening Result Set from moduleAllInfo");
+      String challengeCategory = new String();
+      int rowNumber = 0; // Identifies the first row, ie the start of the list. This is slightly
+      // different output to every other row
+      while (challenges.next()) {
+        if (!challengeCategory.equalsIgnoreCase(challenges.getString(2))) {
+          challengeCategory = challenges.getString(2);
+          // log.debug("New Category Detected: " + challengeCategory);
+          if (rowNumber > 0) // output prepared for Every row after row 1
+          {
+            output +=
+                "</ul></li><li><a href='javascript:;' class='challengeHeader' >"
+                    + Encode.forHtml(bundle.getString("category." + challengeCategory))
+                    + "</a><ul class='challengeList' style='display: none;'>";
+          } else // output prepared for First row in entire challenge
+          {
+            output +=
+                "<li><a href='javascript:;' class='challengeHeader'>"
+                    + Encode.forHtml(bundle.getString("category." + challengeCategory))
+                    + "</a><ul class='challengeList' style='display: none;'>";
+          }
+          // log.debug("Compiling Challenge Category - " + challengeCategory);
         }
-        // log.debug("Compiling Challenge Category - " + challengeCategory);
+        output += "<li>"; // Starts next LI element
+        if (challenges.getString(4) != null) {
+          output += "<img src='css/images/completed.png'/>"; // Completed marker
+        } else {
+          output += "<img src='css/images/uncompleted.png'/>"; // Incomplete marker
+        }
+        // Final out put compilation
+        output +=
+            "<a class='lesson' id='"
+                + Encode.forHtmlAttribute(challenges.getString(3))
+                + "' href='javascript:;'>"
+                + Encode.forHtml(bundle.getString(challenges.getString(1)))
+                + "</a>";
+        output += "</li>";
+        rowNumber++;
       }
-      output += "<li>"; // Starts next LI element
-      if (challenges.getString(4) != null) {
-        output += "<img src='css/images/completed.png'/>"; // Completed marker
+      // Check if output is empty
+      if (output.isEmpty()) {
+        output = "<li>No challenges found</li>";
       } else {
-        output += "<img src='css/images/uncompleted.png'/>"; // Incomplete marker
+        log.debug("Appending End tags");
+        output += "</ul></li>";
       }
-      // Final out put compilation
-      output +=
-          "<a class='lesson' id='"
-              + Encode.forHtmlAttribute(challenges.getString(3))
-              + "' href='javascript:;'>"
-              + Encode.forHtml(bundle.getString(challenges.getString(1)))
-              + "</a>";
-      output += "</li>";
-      rowNumber++;
-    }
-    // Check if output is empty
-    if (output.isEmpty()) {
-      output = "<li>No challenges found</li>";
-    } else {
-      log.debug("Appending End tags");
-      output += "</ul></li>";
-    }
 
-    Database.closeConnection(conn);
-    log.debug("*** END getChallenges() ***");
-    return output;
+      log.debug("*** END getChallenges() ***");
+      return output;
+    }
   }
 
   /**
@@ -657,8 +647,7 @@ public class Getter {
     int result = 0;
     ResultSet resultSet = null;
     log.debug("*** Getter.getClassCount ***");
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       CallableStatement callstmt = conn.prepareCall("call classCount()");
       log.debug("Gathering classCount ResultSet");
@@ -666,8 +655,6 @@ public class Getter {
       log.debug("Opening Result Set from classCount");
       resultSet.next();
       result = resultSet.getInt(1);
-      Database.closeConnection(conn);
-
     } catch (SQLException e) {
       log.error("Could not execute query: " + e.toString());
       result = 0;
@@ -706,8 +693,7 @@ public class Getter {
   public static String[] getClassInfo(String ApplicationRoot, String classId) {
     String[] result = new String[2];
     log.debug("*** Getter.getClassInfo (Single Class) ***");
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       CallableStatement callstmt = conn.prepareCall("call classFind(?)");
       callstmt.setString(1, classId);
@@ -741,8 +727,7 @@ public class Getter {
     log.debug("*** Getter.getCsrfForum ***");
     log.debug("Getting stored messages from class: " + classId);
     String htmlOutput = new String();
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       if (classId != null) {
         CallableStatement callstmt = conn.prepareCall("call resultMessageByClass(?, ?)");
@@ -783,8 +768,6 @@ public class Getter {
         log.error("User with Null Class detected");
         htmlOutput = "<p><font color='red'>" + bundle.getString("error.noClass") + "</font></p>";
       }
-      Database.closeConnection(conn);
-
     } catch (SQLException e) {
       log.error("Could not execute query: " + e.toString());
       htmlOutput = "<p>" + bundle.getString("error.occurred ") + "</p>";
@@ -810,8 +793,7 @@ public class Getter {
     log.debug("*** Getter.getCsrfForum ***");
     log.debug("Getting stored messages from class: " + classId);
     String htmlOutput = new String();
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       if (classId != null) {
         CallableStatement callstmt = conn.prepareCall("call resultMessageByClass(?, ?)");
@@ -852,8 +834,6 @@ public class Getter {
         log.error("User with Null Class detected");
         htmlOutput = "<p><font color='red'>" + bundle.getString("error.noClass") + "</font></p>";
       }
-      Database.closeConnection(conn);
-
     } catch (SQLException e) {
       log.error("Could not execute query: " + e.toString());
       htmlOutput = "<p>" + bundle.getString("error.occurred") + "</p>";
@@ -875,8 +855,7 @@ public class Getter {
     log.debug("*** Getter.getFeedback ***");
 
     String result = new String();
-    try {
-      Connection conn = Database.getCoreConnection(applicationRoot);
+    try (Connection conn = Database.getCoreConnection(applicationRoot)) {
 
       log.debug("Preparing moduleFeedback call");
       CallableStatement callstmnt = conn.prepareCall("call moduleFeedback(?)");
@@ -938,8 +917,6 @@ public class Getter {
         result = new String();
       }
 
-      Database.closeConnection(conn);
-
     } catch (SQLException e) {
       log.error("moduleFeedback Failure: " + e.toString());
       result = null;
@@ -971,8 +948,7 @@ public class Getter {
     ResourceBundle bundle = ResourceBundle.getBundle("i18n.text", locale);
     ResourceBundle levelNames = ResourceBundle.getBundle("i18n.moduleGenerics.moduleNames", locale);
 
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       CallableStatement callstmt = conn.prepareCall("call moduleIncrementalInfo(?)");
       callstmt.setString(1, userId);
@@ -1055,8 +1031,6 @@ public class Getter {
               + Encode.forHtml(bundle.getString("generic.text.sorryError"))
               + "\");</script>";
 
-      Database.closeConnection(conn);
-
     } catch (Exception e) {
       log.error("Challenge Retrieval: " + e.toString());
     }
@@ -1086,8 +1060,7 @@ public class Getter {
     ResourceBundle bundle = ResourceBundle.getBundle("i18n.text", locale);
     ResourceBundle levelNames = ResourceBundle.getBundle("i18n.moduleGenerics.moduleNames", locale);
 
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       CallableStatement callstmt = conn.prepareCall("call moduleIncrementalInfo(?)");
       callstmt.setString(1, userId);
@@ -1162,8 +1135,6 @@ public class Getter {
         // into Footer
       }
 
-      Database.closeConnection(conn);
-
     } catch (Exception e) {
       log.error("Challenge Retrieval: " + e.toString());
     }
@@ -1185,8 +1156,7 @@ public class Getter {
   public static String getJsonScore(String applicationRoot, String classId) {
     log.debug("classId: " + classId);
     String result = new String();
-    try {
-      Connection conn = Database.getCoreConnection(applicationRoot);
+    try (Connection conn = Database.getCoreConnection(applicationRoot)) {
 
       // Returns User's: Name, # of Completed modules and Score
       CallableStatement callstmnt = null;
@@ -1343,8 +1313,6 @@ public class Getter {
         result = new String();
       }
 
-      Database.closeConnection(conn);
-
     } catch (SQLException e) {
       log.error("getJsonScore Failure: " + e.toString());
       result = null;
@@ -1370,8 +1338,7 @@ public class Getter {
     // Getting Translated Level Names
     ResourceBundle bundle = ResourceBundle.getBundle("i18n.moduleGenerics.moduleNames", lang);
     String output = new String();
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       // Get the lesson modules
       CallableStatement callstmt = conn.prepareCall("call lessonInfo(?)");
@@ -1403,8 +1370,6 @@ public class Getter {
       } else {
         log.debug("Lesson List returned");
       }
-      Database.closeConnection(conn);
-
     } catch (Exception e) {
       log.error("lesson Retrieval: " + e.toString());
     }
@@ -1428,8 +1393,7 @@ public class Getter {
     log.debug("*** Getter.getModuleAddress ***");
     String output = new String();
     String type = new String();
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       CallableStatement callstmt = conn.prepareCall("call moduleGetHash(?, ?)");
       callstmt.setString(1, moduleId);
@@ -1445,8 +1409,6 @@ public class Getter {
         type = "lessons";
       }
       output = type + "/" + modules.getString(1) + ".jsp";
-      Database.closeConnection(conn);
-
     } catch (Exception e) {
       log.error("Module Hash Retrieval: " + e.toString());
       log.error("moduleID = " + moduleId);
@@ -1466,8 +1428,7 @@ public class Getter {
   public static String getModuleCategory(String ApplicationRoot, String moduleId) {
     log.debug("*** Getter.getModuleResult ***");
     String theCategory = null;
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       PreparedStatement prepstmt =
           conn.prepareStatement("SELECT moduleCategory FROM modules WHERE moduleId = ?");
@@ -1475,8 +1436,6 @@ public class Getter {
       ResultSet moduleFind = prepstmt.executeQuery();
       moduleFind.next();
       theCategory = moduleFind.getString(1);
-      Database.closeConnection(conn);
-
     } catch (Exception e) {
       log.error("Module did not exist: " + e.toString());
       theCategory = null;
@@ -1493,8 +1452,7 @@ public class Getter {
   public static String getModuleHash(String applicationRoot, String moduleId) {
     log.debug("*** Getter.getModuleHash ***");
     String result = new String();
-    try {
-      Connection conn = Database.getCoreConnection(applicationRoot);
+    try (Connection conn = Database.getCoreConnection(applicationRoot)) {
 
       CallableStatement callstmt = conn.prepareCall("call moduleGetHashById(?)");
       log.debug("Gathering moduleGetHash ResultSet");
@@ -1503,8 +1461,6 @@ public class Getter {
       log.debug("Opening Result Set from moduleGetHash");
       resultSet.next();
       result = resultSet.getString(1);
-      Database.closeConnection(conn);
-
     } catch (SQLException e) {
       log.error("Could not execute moduleGetHash: " + e.toString());
       result = null;
@@ -1524,8 +1480,7 @@ public class Getter {
     log.debug("*** Getter.getModuleIdFromHash ***");
     log.debug("Getting ID from Hash: " + moduleHash);
     String result = new String();
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       CallableStatement callstmt = conn.prepareCall("call moduleGetIdFromHash(?)");
       log.debug("Gathering moduleGetIdFromHash ResultSet");
@@ -1534,8 +1489,6 @@ public class Getter {
       log.debug("Opening Result Set from moduleGetIdFromHash");
       resultSet.next();
       result = resultSet.getString(1);
-      Database.closeConnection(conn);
-
     } catch (SQLException e) {
       log.error("Could not execute query: " + e.toString());
       result = null;
@@ -1554,8 +1507,7 @@ public class Getter {
   public static boolean getModuleKeyType(String ApplicationRoot, String moduleId) {
     log.debug("*** Getter.getModuleKeyType ***");
     boolean theKeyType = true;
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       PreparedStatement prepstmt =
           conn.prepareStatement("SELECT hardcodedKey FROM modules WHERE moduleId = ?");
@@ -1568,8 +1520,6 @@ public class Getter {
       } else {
         log.debug("Module has user specific Key");
       }
-      Database.closeConnection(conn);
-
     } catch (Exception e) {
       log.error("Module did not exist: " + e.toString());
       theKeyType = true;
@@ -1588,8 +1538,7 @@ public class Getter {
   public static String getModuleNameLocaleKey(String applicationRoot, String moduleId) {
     log.debug("*** Getter.getModuleNameLocaleKey ***");
     String result = new String();
-    try {
-      Connection conn = Database.getCoreConnection(applicationRoot);
+    try (Connection conn = Database.getCoreConnection(applicationRoot)) {
 
       CallableStatement callstmt = conn.prepareCall("call moduleGetNameLocale(?)");
       log.debug("Gathering moduleGetNameLocale ResultSet");
@@ -1598,8 +1547,6 @@ public class Getter {
       log.debug("Opening Result Set from moduleGetNameLocale");
       resultSet.next();
       result = resultSet.getString(1);
-      Database.closeConnection(conn);
-
     } catch (SQLException e) {
       log.error("Could not execute moduleGetNameLocale: " + e.toString());
       result = null;
@@ -1616,8 +1563,7 @@ public class Getter {
   public static String getModuleResult(String ApplicationRoot, String moduleId) {
     log.debug("*** Getter.getModuleResult ***");
     String moduleFound = null;
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       CallableStatement callstmt = conn.prepareCall("call moduleGetResult(?)");
       log.debug("Gathering moduleGetResult ResultSet");
@@ -1627,8 +1573,6 @@ public class Getter {
       moduleFind.next();
       log.debug("Module " + moduleFind.getString(1) + " Found");
       moduleFound = moduleFind.getString(2);
-      Database.closeConnection(conn);
-
     } catch (Exception e) {
       log.error("Module did not exist: " + e.toString());
       moduleFound = null;
@@ -1647,8 +1591,7 @@ public class Getter {
   public static String getModuleResultFromHash(String ApplicationRoot, String moduleHash) {
     log.debug("*** Getter.getModuleResultFromHash ***");
     String result = new String();
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       log.debug("hash '" + moduleHash + "'");
       CallableStatement callstmt = conn.prepareCall("call moduleGetResultFromHash(?)");
@@ -1658,8 +1601,6 @@ public class Getter {
       log.debug("Opening Result Set from moduleGetResultFromHash");
       resultSet.next();
       result = resultSet.getString(1);
-      Database.closeConnection(conn);
-
     } catch (SQLException e) {
       log.error("Could not execute query: " + e.toString());
       result = null;
@@ -1678,8 +1619,7 @@ public class Getter {
   public static String getModulesInOptionTags(String ApplicationRoot) {
     log.debug("*** Getter.getModulesInOptionTags ***");
     String output = new String();
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       PreparedStatement callstmt =
           conn.prepareStatement(
@@ -1697,8 +1637,6 @@ public class Getter {
                 + Encode.forHtml(modules.getString(2))
                 + "</option>\n";
       }
-      Database.closeConnection(conn);
-
     } catch (Exception e) {
       log.error("Challenge Retrieval: " + e.toString());
     }
@@ -1716,8 +1654,7 @@ public class Getter {
   public static String getModulesInOptionTagsCTF(String ApplicationRoot) {
     log.debug("*** Getter.getModulesInOptionTags ***");
     String output = new String();
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       PreparedStatement callstmt =
           conn.prepareStatement(
@@ -1735,8 +1672,6 @@ public class Getter {
                 + Encode.forHtml(modules.getString(2))
                 + "</option>\n";
       }
-      Database.closeConnection(conn);
-
     } catch (Exception e) {
       log.error("Challenge Retrieval: " + e.toString());
     }
@@ -1757,8 +1692,7 @@ public class Getter {
     String[] result = new String[2];
     // Getting Translations
     ResourceBundle bundle = ResourceBundle.getBundle("i18n.cheatsheets.solutions", lang);
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       CallableStatement callstmt = conn.prepareCall("call cheatSheetGetSolution(?)");
       log.debug("Gathering cheatSheetGetSolution ResultSet");
@@ -1768,8 +1702,6 @@ public class Getter {
       resultSet.next();
       result[0] = resultSet.getString(1);
       result[1] = bundle.getString(resultSet.getString(2));
-      Database.closeConnection(conn);
-
     } catch (SQLException e) {
       log.error("Could not execute query: " + e.toString());
       result = null;
@@ -1791,8 +1723,7 @@ public class Getter {
     String openModules = new String();
     String closedModules = new String();
     String output = new String();
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       // Get the modules
       CallableStatement callstmt = conn.prepareCall("call moduleAllStatus()");
@@ -1825,8 +1756,6 @@ public class Getter {
               + "</select></td>\n"
               + "</tr>\n";
       log.debug("Module Status Menu returned");
-      Database.closeConnection(conn);
-
     } catch (Exception e) {
       log.error("Module Status Menu: " + e.toString());
     }
@@ -1844,8 +1773,7 @@ public class Getter {
     log.debug("*** Getter.getOpenCloseCategoryMenu ***");
     String theModules = new String();
     String output = new String();
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       // Get the modules
       PreparedStatement prestmt =
@@ -1867,8 +1795,6 @@ public class Getter {
               + theModules
               + "</select>\n";
       log.debug("Module Category Menu returned");
-      Database.closeConnection(conn);
-
     } catch (Exception e) {
       log.error("Module Status Menu: " + e.toString());
     }
@@ -1927,8 +1853,7 @@ public class Getter {
     log.debug("*** Getter.getProgress ***");
 
     String result = new String();
-    try {
-      Connection conn = Database.getCoreConnection(applicationRoot);
+    try (Connection conn = Database.getCoreConnection(applicationRoot)) {
 
       log.debug("Preparing userProgress call");
       CallableStatement callstmnt = conn.prepareCall("call userProgress(?)");
@@ -1961,8 +1886,6 @@ public class Getter {
         result = new String();
       }
 
-      Database.closeConnection(conn);
-
     } catch (SQLException e) {
       log.error("getProgress Failure: " + e.toString());
       result = null;
@@ -1984,8 +1907,7 @@ public class Getter {
     log.debug("*** Getter.getProgressJSON ***");
 
     String result = new String();
-    try {
-      Connection conn = Database.getCoreConnection(applicationRoot);
+    try (Connection conn = Database.getCoreConnection(applicationRoot)) {
 
       log.debug("Preparing userProgress call");
       // Returns User's: Name, # of Completed modules and Score
@@ -2016,8 +1938,6 @@ public class Getter {
       } else {
         result = new String();
       }
-      Database.closeConnection(conn);
-
     } catch (SQLException e) {
       log.error("getProgressJSON Failure: " + e.toString());
       result = null;
@@ -2065,8 +1985,7 @@ public class Getter {
     // Getting Translations
     ResourceBundle bundle = ResourceBundle.getBundle("i18n.text", lang);
     ResourceBundle levelNames = ResourceBundle.getBundle("i18n.moduleGenerics.moduleNames", lang);
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       String listEntry = new String();
       // Get the modules
@@ -2187,8 +2106,6 @@ public class Getter {
         levelMasterList += "</ul>";
         log.debug("Tournament List returned");
       }
-      Database.closeConnection(conn);
-
     } catch (Exception e) {
       log.error("Tournament List Retrieval: " + e.toString());
     }
@@ -2208,73 +2125,72 @@ public class Getter {
     log.debug("*** Getter.getModulesJson ***");
     JSONArray jsonOutput = new JSONArray();
     new String();
-    Connection conn;
-    try {
-      conn = Database.getCoreConnection();
+    try (Connection conn = Database.getCoreConnection()) {
+      ResourceBundle.getBundle("i18n.text", locale);
+      ResourceBundle levelNames =
+          ResourceBundle.getBundle("i18n.moduleGenerics.moduleNames", locale);
+      try {
+        JSONObject jsonSection = new JSONObject();
+        JSONArray jsonSectionModules = new JSONArray();
+        JSONObject jsonObject = new JSONObject();
+        jsonSection.put("levelMode", floor);
+        jsonOutput.put(jsonSection);
+        jsonSection = new JSONObject();
+
+        // Get the modules
+        CallableStatement callstmt = conn.prepareCall("call getMyModules(?)");
+        callstmt.setString(1, userId);
+        log.debug("Gathering getMyModules ResultSet for user " + userId);
+        ResultSet levels = callstmt.executeQuery();
+        boolean thisModuleIsOpen =
+            true; // If Incremental Mode is enabled, after all the modules that have been
+        // completed have been added to the JSON Array the next level will be
+        // labeled as open and the rest as closed
+        while (levels.next()) {
+          jsonObject = new JSONObject();
+          boolean moduleCompleted = levels.getString(4) != null;
+          jsonObject.put("moduleCompleted", moduleCompleted);
+          jsonObject.put("moduleId", levels.getString(3));
+          jsonObject.put("moduleType", levels.getString(5));
+          jsonObject.put("moduleName", levelNames.getString(levels.getString(1)));
+          jsonObject.put("moduleCategory", levelNames.getString("category." + levels.getString(2)));
+          jsonObject.put(
+              "difficultyCategory", getTounnamentSectionFromRankNumber(levels.getInt(7)));
+          jsonObject.put("moduleScore", levels.getString(6));
+          jsonObject.put("moduleRank", levels.getInt(7));
+          jsonObject.put("scoredPoints", levels.getString(8)); // Could be null
+          jsonObject.put("medalEarned", levels.getString(9)); // Could be null
+          if (ModulePlan.isIncrementalFloor()) {
+            boolean moduleOpen;
+            if (moduleCompleted
+                || (!moduleCompleted && thisModuleIsOpen)) // If its completed or if this is the
+            // first not completed
+            {
+              moduleOpen = true;
+              if (!moduleCompleted && thisModuleIsOpen) {
+                log.debug(
+                    levelNames.getString(levels.getString(1))
+                        + " is the Next Module for user "
+                        + userId);
+                thisModuleIsOpen = false; // Stop this from being set again
+              }
+            } else {
+              moduleOpen = false;
+            }
+            jsonObject.put("moduleOpen", moduleOpen);
+          }
+          jsonSectionModules.put(jsonObject);
+        }
+        jsonSection.put("modules", jsonSectionModules);
+        jsonOutput.put(jsonSection);
+      } catch (Exception e) {
+        log.error("Module List Retrieval: " + e.toString());
+      }
+      return jsonOutput;
     } catch (SQLException | IOException e) {
       log.error("Could not connect to core database: " + e.toString());
       throw new RuntimeException(e);
     }
-    ResourceBundle.getBundle("i18n.text", locale);
-    ResourceBundle levelNames = ResourceBundle.getBundle("i18n.moduleGenerics.moduleNames", locale);
-    try {
-      JSONObject jsonSection = new JSONObject();
-      JSONArray jsonSectionModules = new JSONArray();
-      JSONObject jsonObject = new JSONObject();
-      jsonSection.put("levelMode", floor);
-      jsonOutput.put(jsonSection);
-      jsonSection = new JSONObject();
-
-      // Get the modules
-      CallableStatement callstmt = conn.prepareCall("call getMyModules(?)");
-      callstmt.setString(1, userId);
-      log.debug("Gathering getMyModules ResultSet for user " + userId);
-      ResultSet levels = callstmt.executeQuery();
-      boolean thisModuleIsOpen =
-          true; // If Incremental Mode is enabled, after all the modules that have been
-      // completed have been added to the JSON Array the next level will be
-      // labeled as open and the rest as closed
-      while (levels.next()) {
-        jsonObject = new JSONObject();
-        boolean moduleCompleted = levels.getString(4) != null;
-        jsonObject.put("moduleCompleted", moduleCompleted);
-        jsonObject.put("moduleId", levels.getString(3));
-        jsonObject.put("moduleType", levels.getString(5));
-        jsonObject.put("moduleName", levelNames.getString(levels.getString(1)));
-        jsonObject.put("moduleCategory", levelNames.getString("category." + levels.getString(2)));
-        jsonObject.put("difficultyCategory", getTounnamentSectionFromRankNumber(levels.getInt(7)));
-        jsonObject.put("moduleScore", levels.getString(6));
-        jsonObject.put("moduleRank", levels.getInt(7));
-        jsonObject.put("scoredPoints", levels.getString(8)); // Could be null
-        jsonObject.put("medalEarned", levels.getString(9)); // Could be null
-        if (ModulePlan.isIncrementalFloor()) {
-          boolean moduleOpen;
-          if (moduleCompleted
-              || (!moduleCompleted && thisModuleIsOpen)) // If its completed or if this is the
-          // first not completed
-          {
-            moduleOpen = true;
-            if (!moduleCompleted && thisModuleIsOpen) {
-              log.debug(
-                  levelNames.getString(levels.getString(1))
-                      + " is the Next Module for user "
-                      + userId);
-              thisModuleIsOpen = false; // Stop this from being set again
-            }
-          } else {
-            moduleOpen = false;
-          }
-          jsonObject.put("moduleOpen", moduleOpen);
-        }
-        jsonSectionModules.put(jsonObject);
-      }
-      jsonSection.put("modules", jsonSectionModules);
-      jsonOutput.put(jsonSection);
-    } catch (Exception e) {
-      log.error("Module List Retrieval: " + e.toString());
-    }
-    Database.closeConnection(conn);
-    return jsonOutput;
   }
 
   /**
@@ -2286,8 +2202,7 @@ public class Getter {
     log.debug("*** Getter.getUserClass ***");
     String result = new String();
     userName = userName.toLowerCase();
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       CallableStatement callstmt = conn.prepareCall("call userClassId(?)");
       log.debug("Gathering userClassId ResultSet");
@@ -2297,8 +2212,6 @@ public class Getter {
       resultSet.next();
       result = resultSet.getString(1);
       log.debug("Found " + result);
-      Database.closeConnection(conn);
-
     } catch (SQLException e) {
       log.error("Could not execute userClassId: " + e.toString());
       result = new String();
@@ -2318,8 +2231,7 @@ public class Getter {
 
     userName = userName.toLowerCase();
 
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       CallableStatement callstmt = conn.prepareCall("call userGetIdByName(?)");
       log.debug("Gathering userGetIdByName ResultSet");
@@ -2328,8 +2240,6 @@ public class Getter {
       log.debug("Opening Result Set from userGetIdByName");
       resultSet.next();
       result = resultSet.getString(1);
-      Database.closeConnection(conn);
-
     } catch (SQLException e) {
       log.error("Could not execute query: " + e.toString());
       result = null;
@@ -2346,8 +2256,7 @@ public class Getter {
   public static String getUserName(String ApplicationRoot, String userId) {
     log.debug("*** Getter.getUserName ***");
     String result = new String();
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       CallableStatement callstmt = conn.prepareCall("call userGetNameById(?)");
       log.debug("Gathering userGetNameById ResultSet");
@@ -2356,8 +2265,6 @@ public class Getter {
       log.debug("Opening Result Set from userGetNameById");
       resultSet.next();
       result = resultSet.getString(1);
-      Database.closeConnection(conn);
-
     } catch (SQLException e) {
       log.error("Could not execute query: " + e.toString());
       result = null;
@@ -2382,8 +2289,7 @@ public class Getter {
 
     boolean result = false;
 
-    try {
-      Connection conn = Database.getCoreConnection(applicationRoot);
+    try (Connection conn = Database.getCoreConnection(applicationRoot)) {
 
       log.debug("Preparing csrfLevelComplete call");
       PreparedStatement callstmnt = conn.prepareCall("call csrfLevelComplete(?, ?)");
@@ -2398,8 +2304,6 @@ public class Getter {
       if (result) {
         log.debug("CSRF Level is complete");
       }
-      Database.closeConnection(conn);
-
     } catch (SQLException e) {
       log.error("csrfLevelComplete Failure: " + e.toString());
       result = false;
@@ -2411,8 +2315,7 @@ public class Getter {
   public static boolean isModuleOpen(String ApplicationRoot, String moduleId) {
     log.debug("*** Getter.isModuleOpen ***");
     boolean result = false;
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       // Get the modules
       PreparedStatement prepStmt =
@@ -2425,8 +2328,6 @@ public class Getter {
         }
       }
       rs.close();
-      Database.closeConnection(conn);
-
     } catch (Exception e) {
       log.error("isModuleOpen Error: " + e.toString());
     }
@@ -2467,8 +2368,7 @@ public class Getter {
     log.debug("*** Getter.findAdminById ***");
     boolean userFound = false;
     // Get connection
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       CallableStatement callstmt = conn.prepareCall("call adminFindById(?)");
       log.debug("Gathering adminFindById ResultSet");
@@ -2479,8 +2379,6 @@ public class Getter {
       log.debug(
           "Admin Found: " + userFind.getString(1)); // This line will not execute if admin not found
       userFound = true;
-      Database.closeConnection(conn);
-
     } catch (Exception e) {
       log.error("Admin does not exist: " + e.toString());
       userFound = false;
@@ -2493,355 +2391,355 @@ public class Getter {
     boolean adminCheatStatus = false;
     log.debug("*** Getter.getAdminCheatStatus ***");
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
-    log.debug("Getting admin cheat setting");
-    PreparedStatement callstmt =
-        conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
+      log.debug("Getting admin cheat setting");
+      PreparedStatement callstmt =
+          conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
 
-    callstmt.setString(1, "adminCheatsEnabled");
+      callstmt.setString(1, "adminCheatsEnabled");
 
-    ResultSet cheatResult = callstmt.executeQuery();
+      ResultSet cheatResult = callstmt.executeQuery();
 
-    cheatResult.next();
+      cheatResult.next();
 
-    adminCheatStatus = cheatResult.getBoolean(1);
+      adminCheatStatus = cheatResult.getBoolean(1);
 
-    log.debug("Value found: " + adminCheatStatus);
+      log.debug("Value found: " + adminCheatStatus);
 
-    Database.closeConnection(conn);
-    log.debug("*** END getAdminCheatStatus ***");
-    return adminCheatStatus;
+      log.debug("*** END getAdminCheatStatus ***");
+      return adminCheatStatus;
+    }
   }
 
   public static boolean getPlayerCheatStatus(String ApplicationRoot) throws SQLException {
     boolean getPlayerCheatStatus = false;
     log.debug("*** Getter.getPlayerCheatStatus ***");
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
-    log.debug("Getting player cheat setting");
-    PreparedStatement callstmt =
-        conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
+      log.debug("Getting player cheat setting");
+      PreparedStatement callstmt =
+          conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
 
-    callstmt.setString(1, "playerCheatsEnabled");
+      callstmt.setString(1, "playerCheatsEnabled");
 
-    ResultSet cheatResult = callstmt.executeQuery();
+      ResultSet cheatResult = callstmt.executeQuery();
 
-    cheatResult.next();
+      cheatResult.next();
 
-    getPlayerCheatStatus = cheatResult.getBoolean(1);
+      getPlayerCheatStatus = cheatResult.getBoolean(1);
 
-    log.debug("Value found: " + getPlayerCheatStatus);
+      log.debug("Value found: " + getPlayerCheatStatus);
 
-    Database.closeConnection(conn);
-    log.debug("*** END getPlayerCheatStatus ***");
-    return getPlayerCheatStatus;
+      log.debug("*** END getPlayerCheatStatus ***");
+      return getPlayerCheatStatus;
+    }
   }
 
   public static String getModuleLayout(String ApplicationRoot) throws SQLException {
     String theModuleLayout = "";
     log.debug("*** Getter.getModuleLayout ***");
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
-    log.debug("Getting module layout setting");
-    PreparedStatement callstmt =
-        conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
+      log.debug("Getting module layout setting");
+      PreparedStatement callstmt =
+          conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
 
-    callstmt.setString(1, "moduleLayout");
+      callstmt.setString(1, "moduleLayout");
 
-    ResultSet layoutResult = callstmt.executeQuery();
+      ResultSet layoutResult = callstmt.executeQuery();
 
-    layoutResult.next();
+      layoutResult.next();
 
-    theModuleLayout = layoutResult.getString(1);
+      theModuleLayout = layoutResult.getString(1);
 
-    log.debug("Value found: " + theModuleLayout);
+      log.debug("Value found: " + theModuleLayout);
 
-    Database.closeConnection(conn);
-    log.debug("*** END getModuleLayout ***");
-    return theModuleLayout;
+      log.debug("*** END getModuleLayout ***");
+      return theModuleLayout;
+    }
   }
 
   public static boolean getFeedbackStatus(String ApplicationRoot) throws SQLException {
     boolean theFeedbackStatus = false;
     log.debug("*** Getter.getFeedbackStatus ***");
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
-    log.debug("Getting feedback status setting");
-    PreparedStatement callstmt =
-        conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
+      log.debug("Getting feedback status setting");
+      PreparedStatement callstmt =
+          conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
 
-    callstmt.setString(1, "enableFeedback");
+      callstmt.setString(1, "enableFeedback");
 
-    ResultSet feedbackResult = callstmt.executeQuery();
+      ResultSet feedbackResult = callstmt.executeQuery();
 
-    feedbackResult.next();
+      feedbackResult.next();
 
-    theFeedbackStatus = feedbackResult.getBoolean(1);
+      theFeedbackStatus = feedbackResult.getBoolean(1);
 
-    log.debug("Value found: " + theFeedbackStatus);
+      log.debug("Value found: " + theFeedbackStatus);
 
-    Database.closeConnection(conn);
-    log.debug("*** END getFeedbackStatus ***");
-    return theFeedbackStatus;
+      log.debug("*** END getFeedbackStatus ***");
+      return theFeedbackStatus;
+    }
   }
 
   public static boolean getRegistrationStatus(String ApplicationRoot) throws SQLException {
     boolean theRegistrationStatus = false;
     log.debug("*** Getter.getRegistrationStatus ***");
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
-    log.debug("Getting registration status setting");
-    PreparedStatement callstmt =
-        conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
+      log.debug("Getting registration status setting");
+      PreparedStatement callstmt =
+          conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
 
-    callstmt.setString(1, "openRegistration");
+      callstmt.setString(1, "openRegistration");
 
-    ResultSet registrationResult = callstmt.executeQuery();
+      ResultSet registrationResult = callstmt.executeQuery();
 
-    registrationResult.next();
+      registrationResult.next();
 
-    theRegistrationStatus = registrationResult.getBoolean(1);
+      theRegistrationStatus = registrationResult.getBoolean(1);
 
-    log.debug("Value found: " + theRegistrationStatus);
+      log.debug("Value found: " + theRegistrationStatus);
 
-    Database.closeConnection(conn);
-    log.debug("*** END getRegistrationStatus ***");
-    return theRegistrationStatus;
+      log.debug("*** END getRegistrationStatus ***");
+      return theRegistrationStatus;
+    }
   }
 
   public static String getScoreboardStatus(String ApplicationRoot) throws SQLException {
     String theScoreboardStatus = "";
     log.debug("*** Getter.getScoreboardStatus ***");
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
-    log.debug("Setting scoreboard status setting");
-    PreparedStatement callstmt =
-        conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
+      log.debug("Setting scoreboard status setting");
+      PreparedStatement callstmt =
+          conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
 
-    callstmt.setString(1, "scoreboardStatus");
+      callstmt.setString(1, "scoreboardStatus");
 
-    ResultSet scoreboardResult = callstmt.executeQuery();
+      ResultSet scoreboardResult = callstmt.executeQuery();
 
-    scoreboardResult.next();
+      scoreboardResult.next();
 
-    theScoreboardStatus = scoreboardResult.getString(1);
+      theScoreboardStatus = scoreboardResult.getString(1);
 
-    log.debug("Value found: " + theScoreboardStatus);
+      log.debug("Value found: " + theScoreboardStatus);
 
-    Database.closeConnection(conn);
-    log.debug("*** END getScoreboardStatus ***");
-    return theScoreboardStatus;
+      log.debug("*** END getScoreboardStatus ***");
+      return theScoreboardStatus;
+    }
   }
 
   public static String getScoreboardClass(String ApplicationRoot) throws SQLException {
     String theScoreboardClass = "";
     log.debug("*** Getter.getScoreboardClass ***");
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
-    log.debug("Getting scoreboard class setting");
-    PreparedStatement callstmt =
-        conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
+      log.debug("Getting scoreboard class setting");
+      PreparedStatement callstmt =
+          conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
 
-    callstmt.setString(1, "scoreboardClass");
+      callstmt.setString(1, "scoreboardClass");
 
-    ResultSet scoreboardResult = callstmt.executeQuery();
+      ResultSet scoreboardResult = callstmt.executeQuery();
 
-    scoreboardResult.next();
+      scoreboardResult.next();
 
-    theScoreboardClass = scoreboardResult.getString(1);
+      theScoreboardClass = scoreboardResult.getString(1);
 
-    log.debug("Value found: " + theScoreboardClass);
+      log.debug("Value found: " + theScoreboardClass);
 
-    Database.closeConnection(conn);
-    log.debug("*** END getScoreboardClass ***");
-    return theScoreboardClass;
+      log.debug("*** END getScoreboardClass ***");
+      return theScoreboardClass;
+    }
   }
 
   public static Boolean getStartTimeStatus(String ApplicationRoot) throws SQLException {
     Boolean theStartTimeStatus = null;
     log.debug("*** Getter.getStartTimeStatus ***");
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
-    log.debug("Getting start time setting");
-    PreparedStatement callstmt =
-        conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
+      log.debug("Getting start time setting");
+      PreparedStatement callstmt =
+          conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
 
-    callstmt.setString(1, "hasStartTime");
+      callstmt.setString(1, "hasStartTime");
 
-    ResultSet timestampResult = callstmt.executeQuery();
+      ResultSet timestampResult = callstmt.executeQuery();
 
-    timestampResult.next();
+      timestampResult.next();
 
-    theStartTimeStatus = timestampResult.getBoolean(1);
+      theStartTimeStatus = timestampResult.getBoolean(1);
 
-    log.debug("Value found: " + theStartTimeStatus);
+      log.debug("Value found: " + theStartTimeStatus);
 
-    Database.closeConnection(conn);
-    log.debug("*** END getStartTimeStatus ***");
-    return theStartTimeStatus;
+      log.debug("*** END getStartTimeStatus ***");
+      return theStartTimeStatus;
+    }
   }
 
   public static LocalDateTime getStartTime(String ApplicationRoot) throws SQLException {
     LocalDateTime theStartTimeStatus = null;
     log.debug("*** Getter.getStartTimeStatus ***");
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
-    log.debug("Getting start time");
-    PreparedStatement callstmt =
-        conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
+      log.debug("Getting start time");
+      PreparedStatement callstmt =
+          conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
 
-    callstmt.setString(1, "startTime");
+      callstmt.setString(1, "startTime");
 
-    ResultSet timestampResult = callstmt.executeQuery();
+      ResultSet timestampResult = callstmt.executeQuery();
 
-    timestampResult.next();
+      timestampResult.next();
 
-    String dateTimeString = timestampResult.getString(1);
+      String dateTimeString = timestampResult.getString(1);
 
-    log.debug("Value found: " + dateTimeString);
+      log.debug("Value found: " + dateTimeString);
 
-    theStartTimeStatus = LocalDateTime.parse(dateTimeString);
+      theStartTimeStatus = LocalDateTime.parse(dateTimeString);
 
-    Database.closeConnection(conn);
-    log.debug("*** END getStartTime ***");
-    return theStartTimeStatus;
+      log.debug("*** END getStartTime ***");
+      return theStartTimeStatus;
+    }
   }
 
   public static Boolean getLockTimeStatus(String ApplicationRoot) throws SQLException {
     Boolean theLockTimeStatus = null;
     log.debug("*** Getter.getLockTimeStatus ***");
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
-    log.debug("Getting lock time setting");
-    PreparedStatement callstmt =
-        conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
+      log.debug("Getting lock time setting");
+      PreparedStatement callstmt =
+          conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
 
-    callstmt.setString(1, "hasLockTime");
+      callstmt.setString(1, "hasLockTime");
 
-    ResultSet timestampResult = callstmt.executeQuery();
+      ResultSet timestampResult = callstmt.executeQuery();
 
-    timestampResult.next();
+      timestampResult.next();
 
-    theLockTimeStatus = timestampResult.getBoolean(1);
+      theLockTimeStatus = timestampResult.getBoolean(1);
 
-    log.debug("Value found: " + theLockTimeStatus);
+      log.debug("Value found: " + theLockTimeStatus);
 
-    Database.closeConnection(conn);
-    log.debug("*** END getLockTimeStatus ***");
-    return theLockTimeStatus;
+      log.debug("*** END getLockTimeStatus ***");
+      return theLockTimeStatus;
+    }
   }
 
   public static LocalDateTime getLockTime(String ApplicationRoot) throws SQLException {
     LocalDateTime theLockTimeStatus = null;
     log.debug("*** Getter.getLockTimeStatus ***");
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
-    log.debug("Getting lock time");
-    PreparedStatement callstmt =
-        conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
+      log.debug("Getting lock time");
+      PreparedStatement callstmt =
+          conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
 
-    callstmt.setString(1, "lockTime");
+      callstmt.setString(1, "lockTime");
 
-    ResultSet timestampResult = callstmt.executeQuery();
+      ResultSet timestampResult = callstmt.executeQuery();
 
-    timestampResult.next();
+      timestampResult.next();
 
-    String dateTimeString = timestampResult.getString(1);
+      String dateTimeString = timestampResult.getString(1);
 
-    log.debug("Value found: " + dateTimeString);
+      log.debug("Value found: " + dateTimeString);
 
-    theLockTimeStatus = LocalDateTime.parse(dateTimeString);
+      theLockTimeStatus = LocalDateTime.parse(dateTimeString);
 
-    Database.closeConnection(conn);
-    log.debug("*** END getLockTime ***");
-    return theLockTimeStatus;
+      log.debug("*** END getLockTime ***");
+      return theLockTimeStatus;
+    }
   }
 
   public static Boolean getEndTimeStatus(String ApplicationRoot) throws SQLException {
     Boolean theEndTimeStatus = null;
     log.debug("*** Getter.getEndTimeStatus ***");
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
-    log.debug("Getting end time setting");
-    PreparedStatement callstmt =
-        conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
+      log.debug("Getting end time setting");
+      PreparedStatement callstmt =
+          conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
 
-    callstmt.setString(1, "hasEndTime");
+      callstmt.setString(1, "hasEndTime");
 
-    ResultSet timestampResult = callstmt.executeQuery();
+      ResultSet timestampResult = callstmt.executeQuery();
 
-    timestampResult.next();
+      timestampResult.next();
 
-    theEndTimeStatus = timestampResult.getBoolean(1);
+      theEndTimeStatus = timestampResult.getBoolean(1);
 
-    log.debug("Value found: " + theEndTimeStatus);
+      log.debug("Value found: " + theEndTimeStatus);
 
-    Database.closeConnection(conn);
-    log.debug("*** END getEndTimeStatus ***");
-    return theEndTimeStatus;
+      log.debug("*** END getEndTimeStatus ***");
+      return theEndTimeStatus;
+    }
   }
 
   public static LocalDateTime getEndTime(String ApplicationRoot) throws SQLException {
     LocalDateTime theEndTimeStatus = null;
     log.debug("*** Getter.getEndTimeStatus ***");
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
-    log.debug("Getting end time");
-    PreparedStatement callstmt =
-        conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
+      log.debug("Getting end time");
+      PreparedStatement callstmt =
+          conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
 
-    callstmt.setString(1, "endTime");
+      callstmt.setString(1, "endTime");
 
-    ResultSet timestampResult = callstmt.executeQuery();
+      ResultSet timestampResult = callstmt.executeQuery();
 
-    timestampResult.next();
+      timestampResult.next();
 
-    String dateTimeString = timestampResult.getString(1);
+      String dateTimeString = timestampResult.getString(1);
 
-    log.debug("Value found: " + dateTimeString);
+      log.debug("Value found: " + dateTimeString);
 
-    theEndTimeStatus = LocalDateTime.parse(dateTimeString);
+      theEndTimeStatus = LocalDateTime.parse(dateTimeString);
 
-    Database.closeConnection(conn);
-    log.debug("*** END getEndTime ***");
-    return theEndTimeStatus;
+      log.debug("*** END getEndTime ***");
+      return theEndTimeStatus;
+    }
   }
 
   public static String getDefaultClass(String ApplicationRoot) throws SQLException {
     String theDefaultClass = null;
     log.debug("*** Getter.getDefaultClass ***");
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
-    log.debug("Getting default class");
-    PreparedStatement callstmt =
-        conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
+      log.debug("Getting default class");
+      PreparedStatement callstmt =
+          conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
 
-    callstmt.setString(1, "defaultClass");
+      callstmt.setString(1, "defaultClass");
 
-    ResultSet classResult = callstmt.executeQuery();
+      ResultSet classResult = callstmt.executeQuery();
 
-    classResult.next();
+      classResult.next();
 
-    theDefaultClass = classResult.getString(1);
+      theDefaultClass = classResult.getString(1);
 
-    log.debug("Value found: " + theDefaultClass);
+      log.debug("Value found: " + theDefaultClass);
 
-    Database.closeConnection(conn);
-    log.debug("*** END getDefaultClass ***");
-    return theDefaultClass;
+      log.debug("*** END getDefaultClass ***");
+      return theDefaultClass;
+    }
   }
 }

--- a/src/main/java/dbProcs/Getter.java
+++ b/src/main/java/dbProcs/Getter.java
@@ -110,7 +110,7 @@ public class Getter {
         if (userResult.next()) {
           log.debug(
               "User Found"); // User found if a row is in the database, this line will not work if
-                             // the
+          // the
           // result
           // set is empty
           userFound = true;
@@ -412,7 +412,7 @@ public class Getter {
           userFound = true;
           log.debug(
               "User Found"); // User found if a row is in the database, this line will not work if
-                             // the
+          // the
           // result
           // set is empty
         } else {

--- a/src/main/java/listeners/DatabaseLifecycleListener.java
+++ b/src/main/java/listeners/DatabaseLifecycleListener.java
@@ -7,6 +7,7 @@ import javax.servlet.ServletContextListener;
 import javax.servlet.annotation.WebListener;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import servlets.Setup;
 
 /**
  * Servlet context listener for managing database connection pool lifecycle. Initializes connection
@@ -43,6 +44,9 @@ public class DatabaseLifecycleListener implements ServletContextListener {
       // Note: MongoDB connections are lazy-initialized on first use
       // since MongoClient has its own internal connection pool
       log.info("MongoDB connections will be initialized on first use");
+
+      boolean installed = Setup.isInstalled();
+      log.info("Setup.isInstalled() cached at startup: " + installed);
 
     } catch (RuntimeException e) {
       // Catch RuntimeException (including configuration errors) to prevent

--- a/src/main/java/servlets/Setup.java
+++ b/src/main/java/servlets/Setup.java
@@ -395,11 +395,12 @@ public class Setup extends HttpServlet {
         }
       }
 
-      if (!installed) {
+      if (installed) {
+        installedCached = true;
+      } else {
         generateAuth();
       }
 
-      installedCached = installed;
       return installed;
     }
   }

--- a/src/main/java/servlets/Setup.java
+++ b/src/main/java/servlets/Setup.java
@@ -41,6 +41,8 @@ public class Setup extends HttpServlet {
   private static final Logger log = LogManager.getLogger(Setup.class);
   private static final long serialVersionUID = -892181347446991016L;
 
+  private static volatile Boolean installedCached = null;
+
   public void doPost(HttpServletRequest request, HttpServletResponse response)
       throws ServletException, IOException {
     // Translation Stuff
@@ -285,6 +287,7 @@ public class Setup extends HttpServlet {
             // Clean up File as it is not needed anymore. Will Cause a new one to be
             // generated next time too
             removeAuthFile();
+            resetInstalledCache();
           }
 
           if (enableMongoChallenge.equalsIgnoreCase("enable")) {
@@ -367,26 +370,43 @@ public class Setup extends HttpServlet {
   }
 
   public static boolean isInstalled() {
-    boolean isInstalled = false;
+    Boolean cached = installedCached;
+    if (cached != null) {
+      return cached;
+    }
 
-    Properties prop = getDBProps();
-
-    if (prop != null) {
-
-      try (Connection coreConnection = Database.getCoreConnection(null)) {
-        if (coreConnection != null) {
-          isInstalled = true;
-        }
-      } catch (SQLException e) {
-        log.info("isInstalled got SQL exception " + e.toString() + ", assuming not installed.");
+    synchronized (Setup.class) {
+      cached = installedCached;
+      if (cached != null) {
+        return cached;
       }
-    }
 
-    if (!isInstalled) {
-      generateAuth();
-    }
+      boolean installed = false;
 
-    return isInstalled;
+      Properties prop = getDBProps();
+
+      if (prop != null) {
+        try (Connection coreConnection = Database.getCoreConnection(null)) {
+          if (coreConnection != null) {
+            installed = true;
+          }
+        } catch (SQLException e) {
+          log.info("isInstalled got SQL exception " + e.toString() + ", assuming not installed.");
+        }
+      }
+
+      if (!installed) {
+        generateAuth();
+      }
+
+      installedCached = installed;
+      return installed;
+    }
+  }
+
+  /** Clear the cached installation status so the next call re-evaluates. */
+  public static void resetInstalledCache() {
+    installedCached = null;
   }
 
   public static Properties getDBProps() {

--- a/src/main/resources/database.properties.example
+++ b/src/main/resources/database.properties.example
@@ -14,16 +14,16 @@ databaseOptions=useUnicode=true&character_set_server=utf8mb4
 # Adjust based on your expected concurrent user load.
 
 # Maximum number of connections in the pool
-# Default: 10
-pool.maximumPoolSize=10
+# Default: 20
+pool.maximumPoolSize=20
 
 # Minimum number of idle connections to maintain
-# Default: 2
-pool.minimumIdle=2
+# Default: 5
+pool.minimumIdle=5
 
 # Maximum time (ms) to wait for a connection from the pool
-# Default: 30000 (30 seconds)
-pool.connectionTimeout=30000
+# Default: 5000 (5 seconds)
+pool.connectionTimeout=5000
 
 # Maximum time (ms) a connection can sit idle in the pool
 # Default: 600000 (10 minutes)

--- a/tests/load/load-test.py
+++ b/tests/load/load-test.py
@@ -2,12 +2,23 @@
 """
 Load test for Security Shepherd connection pooling (issue #536).
 
-Simulates 20 users: 17 doing normal browsing, 3 running aggressive
-automated scanning. Monitors DB connections and app responsiveness
-to verify the connection pool prevents exhaustion.
+Modes:
+  --target all       Full soak test (default): 20 concurrent users, monitors
+                     DB connections and app responsiveness over time.
+  --target getter    Targeted: tight loops against endpoints backed by Getter.java.
+  --target setter    Targeted: tight loops against endpoints backed by Setter.java.
+  --target getter setter   Both targeted classes sequentially.
+  --methods authUser refreshMenu   Only specific methods within the target class.
+
+Targeted mode runs each endpoint in isolation, checking DB connection count
+before and after to detect leaks. Soak mode runs concurrent traffic.
 
 Usage:
-    python3 load-test.py [--skip-build] [--duration MINUTES] [--users NORMAL AGGRESSIVE]
+    python3 load-test.py --skip-setup --target getter
+    python3 load-test.py --skip-setup --target getter --concurrency 10
+    python3 load-test.py --skip-setup --target getter --methods authUser refreshMenu
+    python3 load-test.py --skip-setup --target all --duration 5
+    python3 load-test.py --skip-setup --target getter setter --iterations 200 --concurrency 5
 """
 
 import argparse
@@ -27,7 +38,6 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from pathlib import Path
 
-# Disable SSL verification globally (self-signed cert)
 SSL_CTX = ssl.create_default_context()
 SSL_CTX.check_hostname = False
 SSL_CTX.verify_mode = ssl.CERT_NONE
@@ -50,6 +60,87 @@ SPIDER_PATHS = [
 ]
 
 NORMAL_PAGES = ["/login.jsp", "/index.jsp", "/register.jsp", "/logout"]
+
+MAX_ALLOWED_CONNS = 50
+
+# ── Target Definitions ────────────────────────────────────────────
+#
+# Each entry maps a human-readable method name to the HTTP request
+# that exercises it plus the Java method(s) it covers.  The runner
+# calls these in a tight loop and measures connection growth.
+
+GETTER_TARGETS = {
+    "authUser": {
+        "http": "POST", "path": "/login",
+        "data": {"login": "nonexistent_leak_probe_{i}", "pwd": "wrong"},
+        "auth_required": False,
+        "java": "Getter.authUser — core login, was leaking on failed lookups",
+    },
+    "refreshMenu": {
+        "http": "GET", "path": "/refreshMenu",
+        "auth_required": True,
+        "java": "Getter.getChallenges / getLessons / getTournamentModules / getIncrementalModules",
+    },
+    "apiLevels": {
+        "http": "GET", "path": "/api/levels",
+        "auth_required": True,
+        "java": "Getter.getModulesJson",
+    },
+    "getModule": {
+        "http": "GET", "path": "/getModule",
+        "auth_required": True,
+        "java": "Getter.getModuleAddress + checkPlayerResult",
+    },
+    "getProgress": {
+        "http": "GET", "path": "/getProgress",
+        "auth_required": True,
+        "java": "Getter.getProgress / getJsonScore (admin)",
+    },
+    "getFeedback": {
+        "http": "GET", "path": "/getFeedback",
+        "auth_required": True,
+        "java": "Getter.getFeedback (admin)",
+    },
+    "scoreboard": {
+        "http": "GET", "path": "/scoreboard",
+        "auth_required": True,
+        "java": "Getter.getJsonScore + getScoreboardStatus",
+    },
+    "loginPage": {
+        "http": "GET", "path": "/login.jsp",
+        "auth_required": False,
+        "java": "Getter settings: getRegistrationStatus / getStartTimeStatus / etc.",
+    },
+}
+
+SETTER_TARGETS = {
+    "register": {
+        "http": "POST", "path": "/register",
+        "data": {
+            "userName": "setter_probe_{i}", "passWord": "probe",
+            "passWordConfirm": "probe",
+            "userAddress": "probe_{i}@test.com",
+            "userAddressCnf": "probe_{i}@test.com",
+        },
+        "needs_csrf": True,
+        "csrf_page": "/register.jsp",
+        "auth_required": False,
+        "java": "Setter.userCreate — registration path",
+    },
+    "passwordChange": {
+        "http": "POST", "path": "/passwordChange",
+        "data": {
+            "currentPassword": "{user_pass}",
+            "newPassword": "{user_pass}",
+            "passwordConfirmation": "{user_pass}",
+        },
+        "needs_csrf": True,
+        "auth_required": True,
+        "java": "Setter.updatePassword",
+    },
+}
+
+ALL_TARGETS = {"getter": GETTER_TARGETS, "setter": SETTER_TARGETS}
 
 
 # ── Utilities ──────────────────────────────────────────────────────
@@ -175,9 +266,7 @@ def build_and_start(skip_build, project_root):
     else:
         log("Skipping build (--skip-build)")
 
-    # Check for existing volumes
     stdout, _, _ = docker_compose("down", "-v")
-    # Remove any orphaned volumes
     result = subprocess.run(
         ["docker", "volume", "ls", "-q", "--filter", "name=securityshepherd"],
         capture_output=True, text=True
@@ -219,17 +308,14 @@ def configure_platform():
     """Login as admin, change password, and enable registration."""
     session = ShepherdSession()
 
-    # Get initial session
     log("Logging in as admin (admin/password)...")
     session.get("/login.jsp")
 
-    # Login
     status, body, location = session.post("/login", {
         "login": ADMIN_USER,
         "pwd": ADMIN_DEFAULT_PASS,
     })
 
-    # Change temporary password
     log("Changing admin password...")
     token = session.token
     if not token:
@@ -243,7 +329,6 @@ def configure_platform():
     })
     log("Admin password changed")
 
-    # Enable registration
     log("Enabling registration...")
     token = session.token
     status, body, _ = session.post("/updateRegistration", {"csrfToken": token})
@@ -251,7 +336,6 @@ def configure_platform():
     if "Opened" in body:
         log("Registration enabled")
     elif "Closed" in body:
-        # Was already open, got toggled closed — toggle again
         session.post("/updateRegistration", {"csrfToken": token})
         log("Registration enabled (toggled twice)")
     else:
@@ -296,6 +380,16 @@ def register_users(num_users):
     return created
 
 
+def login_user(username, password):
+    """Login a single user and return the session, or None on failure."""
+    session = ShepherdSession()
+    session.get("/login.jsp")
+    status, body, location = session.post("/login", {"login": username, "pwd": password})
+    if "index.jsp" in str(location):
+        return session
+    return None
+
+
 def login_users(num_users):
     """Login all test users and return their sessions."""
     log("Logging in test users...")
@@ -304,19 +398,12 @@ def login_users(num_users):
 
     for i in range(1, num_users + 1):
         username = f"loadtest_user_{i}"
-        session = ShepherdSession()
-        session.get("/login.jsp")
-
-        status, body, location = session.post("/login", {
-            "login": username,
-            "pwd": username,
-        })
-
-        if "index.jsp" in str(location):
+        session = login_user(username, username)
+        if session:
             sessions[i] = session
             logged_in += 1
         else:
-            warn(f"Login failed for {username} (HTTP {status}, location: {location})")
+            warn(f"Login failed for {username}")
 
     if logged_in == 0:
         fail("No users could log in")
@@ -325,7 +412,181 @@ def login_users(num_users):
     return sessions
 
 
-# ── Traffic Simulation ─────────────────────────────────────────────
+# ── Targeted Scenario Runner ──────────────────────────────────────
+
+
+def _warmup_pool():
+    """Hit the app a few times to let Hikari establish idle connections."""
+    s = ShepherdSession()
+    for _ in range(5):
+        s.get("/login.jsp")
+    time.sleep(2)
+
+
+def _worker_loop(spec, iterations, worker_id, session, conn_samples, errors_count):
+    """Single worker thread: fires requests and periodically samples connections."""
+    user_pass = "loadtest_user_1"
+
+    for i in range(iterations):
+        try:
+            if spec["http"] == "GET":
+                session.get(spec["path"])
+            else:
+                raw_data = spec.get("data", {})
+                data = {}
+                for k, v in raw_data.items():
+                    v = v.replace("{i}", f"{worker_id}_{i}")
+                    v = v.replace("{user_pass}", user_pass)
+                    data[k] = v
+
+                if spec.get("needs_csrf"):
+                    csrf_page = spec.get("csrf_page", spec["path"])
+                    csrf = session.get_csrf_from_page(csrf_page)
+                    if csrf:
+                        data["csrfToken"] = csrf
+                    elif session.token:
+                        data["csrfToken"] = session.token
+
+                session.post(spec["path"], data)
+        except Exception:
+            errors_count.append(1)
+
+        if i % 25 == 24:
+            current = get_connections()
+            if current:
+                conn_samples.append(current)
+
+
+def run_scenario(name, spec, iterations, session=None, concurrency=1):
+    """
+    Run a single endpoint scenario, optionally with concurrent threads.
+    Returns dict with baseline, peak, final connection counts and request stats.
+    """
+    _warmup_pool()
+
+    baseline = get_connections() or 0
+    conn_samples = [baseline]
+    errors_list = []
+
+    if concurrency <= 1:
+        _worker_loop(spec, iterations, 0, session, conn_samples, errors_list)
+    else:
+        def make_session(spec, base_session):
+            if spec.get("auth_required"):
+                s = login_user("loadtest_user_1", "loadtest_user_1")
+                return s if s else base_session
+            return ShepherdSession()
+
+        with ThreadPoolExecutor(max_workers=concurrency) as pool:
+            futures = []
+            for w in range(concurrency):
+                worker_session = session if w == 0 else make_session(spec, session)
+                f = pool.submit(
+                    _worker_loop, spec, iterations, w,
+                    worker_session, conn_samples, errors_list,
+                )
+                futures.append(f)
+            for f in futures:
+                f.result()
+
+    time.sleep(1)
+    final = get_connections() or 0
+    conn_samples.append(final)
+    peak = max(conn_samples)
+
+    return {
+        "baseline": baseline,
+        "peak": peak,
+        "final": final,
+        "iterations": iterations * concurrency,
+        "errors": len(errors_list),
+        "concurrency": concurrency,
+    }
+
+
+def run_targeted_tests(targets_to_run, methods_filter, iterations, concurrency,
+                       admin_session):
+    """Run targeted scenarios and print per-method results."""
+    user_session = login_user("loadtest_user_1", "loadtest_user_1")
+    if not user_session:
+        user_session = admin_session
+
+    results = {}
+    all_passed = True
+
+    for class_name, method_map in targets_to_run.items():
+        print()
+        log(f"Running targeted tests for {class_name.upper()}")
+        print("-" * 59)
+
+        for method_name, spec in method_map.items():
+            if methods_filter and method_name not in methods_filter:
+                continue
+
+            session = admin_session if spec.get("auth_required") else ShepherdSession()
+            if spec.get("auth_required") and user_session:
+                session = user_session
+
+            label = f"{class_name}.{method_name}"
+            conc_label = f" x{concurrency} threads" if concurrency > 1 else ""
+            log(f"  {label} ({spec['http']} {spec['path']}{conc_label})")
+            log(f"    {spec['java']}")
+
+            result = run_scenario(method_name, spec, iterations, session,
+                                  concurrency=concurrency)
+            results[label] = result
+
+            bounded = result["peak"] <= MAX_ALLOWED_CONNS
+            leaked = result["final"] > MAX_ALLOWED_CONNS
+
+            status_color = "\033[0;32m" if (bounded and not leaked) else "\033[0;31m"
+            status_word = "PASS" if (bounded and not leaked) else "FAIL"
+
+            print(f"    Total reqs:  {result['iterations']}"
+                  f" ({iterations}/thread x {concurrency})" if concurrency > 1
+                  else f"    Iterations:  {result['iterations']}")
+            print(f"    Baseline:    {result['baseline']} connections")
+            print(f"    Peak:        {result['peak']} connections")
+            print(f"    Final:       {result['final']} connections")
+            if result["errors"]:
+                print(f"    Errors:      {result['errors']}")
+            print(f"    {status_color}{status_word}\033[0m")
+            print()
+
+            if not bounded or leaked:
+                all_passed = False
+
+    return all_passed, results
+
+
+def print_targeted_summary(results, all_passed):
+    """Print a final summary table for targeted tests."""
+    print()
+    print("=" * 76)
+    print("  TARGETED TEST SUMMARY")
+    print("=" * 76)
+    print()
+    print(f"  {'Scenario':<30} {'Reqs':>6} {'Conc':>5} {'Base':>5} {'Peak':>5} {'Final':>5}  Result")
+    print(f"  {'-'*30} {'-'*6} {'-'*5} {'-'*5} {'-'*5} {'-'*5}  ------")
+
+    for label, r in results.items():
+        bounded = r["peak"] <= MAX_ALLOWED_CONNS
+        leaked = r["final"] > MAX_ALLOWED_CONNS
+        ok = bounded and not leaked
+        mark = "\033[0;32mPASS\033[0m" if ok else "\033[0;31mFAIL\033[0m"
+        conc = r.get("concurrency", 1)
+        print(f"  {label:<30} {r['iterations']:>6} {conc:>5} "
+              f"{r['baseline']:>5} {r['peak']:>5} {r['final']:>5}  {mark}")
+
+    print()
+    if all_passed:
+        print("  \033[0;32mALL SCENARIOS PASSED\033[0m")
+    else:
+        print("  \033[0;31mSOME SCENARIOS FAILED\033[0m")
+    print("=" * 76)
+
+
+# ── Soak Test (original behavior) ─────────────────────────────────
 
 
 def normal_user_traffic(session, duration):
@@ -355,14 +616,12 @@ def aggressive_user_traffic(session, duration):
     while time.time() < end_time:
         path = random.choice(SPIDER_PATHS)
 
-        # GET (spider)
         try:
             session.get(path)
             requests_made += 1
         except Exception:
             pass
 
-        # POST with random params (fuzzer)
         try:
             session.post(path, {
                 "param1": "test",
@@ -390,7 +649,6 @@ def monitor_loop(duration, interval, results_file, stop_event):
             ts = datetime.now().strftime("%H:%M:%S")
             conns = get_connections()
 
-            # Health check
             start = time.time()
             try:
                 req = urllib.request.Request(BASE_URL + "/login.jsp")
@@ -414,7 +672,7 @@ def monitor_loop(duration, interval, results_file, stop_event):
             stop_event.wait(interval)
 
 
-# ── Report ─────────────────────────────────────────────────────────
+# ── Soak Report ────────────────────────────────────────────────────
 
 
 def generate_report(results_file, config, aggressive_total):
@@ -456,7 +714,7 @@ def generate_report(results_file, config, aggressive_total):
 
     print()
     print("=" * 59)
-    print("  LOAD TEST RESULTS")
+    print("  SOAK TEST RESULTS")
     print("=" * 59)
     print()
     print("  Configuration:")
@@ -480,8 +738,8 @@ def generate_report(results_file, config, aggressive_total):
     print()
 
     passed = True
-    if max_conns > 50:
-        print(f"  \033[0;31mFAIL: Max connections ({max_conns}) exceeded 50\033[0m")
+    if max_conns > MAX_ALLOWED_CONNS:
+        print(f"  \033[0;31mFAIL: Max connections ({max_conns}) exceeded {MAX_ALLOWED_CONNS}\033[0m")
         passed = False
     if failed > 0:
         print(f"  \033[0;31mFAIL: {failed} health checks failed\033[0m")
@@ -499,47 +757,22 @@ def generate_report(results_file, config, aggressive_total):
     return passed
 
 
-# ── Main ───────────────────────────────────────────────────────────
-
-
-def main():
-    parser = argparse.ArgumentParser(description="Security Shepherd load test")
-    parser.add_argument("--skip-build", action="store_true", help="Skip Maven/Docker build")
-    parser.add_argument("--duration", type=int, default=5, help="Test duration in minutes (default: 5)")
-    parser.add_argument("--normal-users", type=int, default=17, help="Number of normal users (default: 17)")
-    parser.add_argument("--aggressive-users", type=int, default=3, help="Number of aggressive users (default: 3)")
-    parser.add_argument("--monitor-interval", type=int, default=10, help="Monitor interval in seconds (default: 10)")
-    args = parser.parse_args()
-
+def run_soak_test(args):
+    """Run the original soak test with concurrent users."""
     duration = args.duration * 60
     total_users = args.normal_users + args.aggressive_users
 
     script_dir = Path(__file__).resolve().parent
-    project_root = script_dir.parent.parent
     results_dir = script_dir / "results" / datetime.now().strftime("%Y%m%d-%H%M%S")
     results_dir.mkdir(parents=True, exist_ok=True)
     monitor_file = str(results_dir / "monitor.csv")
 
-    # Step 1: Build and start
-    build_and_start(args.skip_build, str(project_root))
-
-    # Step 2: Wait for services
-    wait_for_services()
-
-    # Step 3: Configure platform (admin login, password change, enable registration)
-    configure_platform()
-
-    # Step 4: Register users
     register_users(total_users)
-
-    # Step 5: Login users
     sessions = login_users(total_users)
 
-    # Step 6: Record baseline
     baseline = get_connections() or 0
     log(f"Baseline DB connections: {baseline}")
 
-    # Step 7: Start monitoring
     log("Starting monitor...")
     stop_monitor = threading.Event()
     monitor_thread = threading.Thread(
@@ -549,26 +782,22 @@ def main():
     )
     monitor_thread.start()
 
-    # Step 8: Start traffic
     log(f"Starting {args.normal_users} normal + {args.aggressive_users} aggressive users for {args.duration} minutes...")
     print()
 
     with ThreadPoolExecutor(max_workers=total_users) as executor:
         futures = {}
 
-        # Normal users
         for i in range(1, args.normal_users + 1):
             if i in sessions:
                 f = executor.submit(normal_user_traffic, sessions[i], duration)
                 futures[f] = ("normal", i)
 
-        # Aggressive users
         for i in range(args.normal_users + 1, total_users + 1):
             if i in sessions:
                 f = executor.submit(aggressive_user_traffic, sessions[i], duration)
                 futures[f] = ("aggressive", i)
 
-        # Wait for all to complete
         aggressive_total = 0
         for future in as_completed(futures):
             kind, user_id = futures[future]
@@ -579,13 +808,12 @@ def main():
             except Exception as e:
                 warn(f"User {user_id} ({kind}) error: {e}")
 
-    # Step 9: Stop monitoring and report
     time.sleep(5)
     stop_monitor.set()
     monitor_thread.join(timeout=10)
 
     print()
-    log("Load test complete. Analyzing results...")
+    log("Soak test complete. Analyzing results...")
 
     config = {
         "normal": args.normal_users,
@@ -594,8 +822,111 @@ def main():
         "baseline": baseline,
     }
 
-    passed = generate_report(monitor_file, config, aggressive_total)
-    sys.exit(0 if passed else 1)
+    return generate_report(monitor_file, config, aggressive_total)
+
+
+# ── Main ───────────────────────────────────────────────────────────
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Security Shepherd load test — targeted or full soak",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+examples:
+  %(prog)s --skip-setup --target getter
+  %(prog)s --skip-setup --target getter --concurrency 10
+  %(prog)s --skip-setup --target getter --methods authUser --iterations 500 --concurrency 20
+  %(prog)s --skip-setup --target getter setter --iterations 200 --concurrency 5
+  %(prog)s --skip-setup --target all --duration 3
+  %(prog)s --list-targets
+""",
+    )
+
+    parser.add_argument(
+        "--target", nargs="+", default=["all"],
+        choices=["all", "getter", "setter"],
+        help="Which classes to test: getter, setter, or all (soak). Default: all",
+    )
+    parser.add_argument(
+        "--methods", nargs="+", default=None,
+        help="Specific methods within the target class (e.g. authUser refreshMenu)",
+    )
+    parser.add_argument(
+        "--iterations", type=int, default=300,
+        help="Requests per thread per scenario in targeted mode (default: 300)",
+    )
+    parser.add_argument(
+        "--concurrency", type=int, default=1,
+        help="Concurrent threads per scenario in targeted mode (default: 1)",
+    )
+    parser.add_argument(
+        "--list-targets", action="store_true",
+        help="List available targets and methods, then exit",
+    )
+
+    parser.add_argument("--skip-build", action="store_true", help="Skip Maven/Docker build")
+    parser.add_argument("--skip-setup", action="store_true",
+                        help="Skip build, service wait, and platform config (app already running)")
+    parser.add_argument("--duration", type=int, default=5,
+                        help="Soak test duration in minutes (default: 5)")
+    parser.add_argument("--normal-users", type=int, default=17,
+                        help="Normal users for soak test (default: 17)")
+    parser.add_argument("--aggressive-users", type=int, default=3,
+                        help="Aggressive users for soak test (default: 3)")
+    parser.add_argument("--monitor-interval", type=int, default=10,
+                        help="Monitor interval in seconds for soak test (default: 10)")
+
+    args = parser.parse_args()
+
+    if args.list_targets:
+        for class_name, methods in ALL_TARGETS.items():
+            print(f"\n  {class_name}:")
+            for method_name, spec in methods.items():
+                auth = "auth" if spec.get("auth_required") else "anon"
+                print(f"    {method_name:<20} {spec['http']:<4} {spec['path']:<20} [{auth}]  {spec['java']}")
+        print()
+        sys.exit(0)
+
+    script_dir = Path(__file__).resolve().parent
+    project_root = script_dir.parent.parent
+
+    is_targeted = "all" not in args.target
+
+    if not args.skip_setup:
+        build_and_start(args.skip_build, str(project_root))
+        wait_for_services()
+        admin_session = configure_platform()
+    else:
+        log("Skipping setup (--skip-setup), assuming app is running")
+        admin_session = ShepherdSession()
+        admin_session.get("/login.jsp")
+        status, body, location = admin_session.post("/login", {
+            "login": ADMIN_USER, "pwd": ADMIN_NEW_PASS,
+        })
+        if "index.jsp" not in str(location):
+            admin_session.post("/login", {
+                "login": ADMIN_USER, "pwd": ADMIN_DEFAULT_PASS,
+            })
+
+    if is_targeted:
+        targets_to_run = {}
+        for t in args.target:
+            if t in ALL_TARGETS:
+                targets_to_run[t] = ALL_TARGETS[t]
+
+        if not args.skip_setup:
+            register_users(2)
+
+        all_passed, results = run_targeted_tests(
+            targets_to_run, args.methods, args.iterations,
+            args.concurrency, admin_session
+        )
+        print_targeted_summary(results, all_passed)
+        sys.exit(0 if all_passed else 1)
+    else:
+        passed = run_soak_test(args)
+        sys.exit(0 if passed else 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Refactors `Getter.java` to use try-with-resources for core connections so Hikari returns connections to the pool under early returns and exceptions.

## Base branch

Targets **`dev#536`** on OWASP — merge after / on top of [#816](https://github.com/OWASP/SecurityShepherd/pull/816) (connection pooling).

## Changes

- try-with-resources across Getter core paths; legacy `ResultSet` APIs unchanged (`getClassInfo` all classes, `getPlayersByClass`, `getAdmins`).
- `ConnectionPool.getCoreActiveConnections()` for tests.
- `GetterCorePoolLeakIT` — bounded active connections under repeated `authUser` calls.

## Test plan

- `mvn test`
- Integration tests with DB (`GetterCorePoolLeakIT`, `GetterIT`)