### PR TITLE
ci: run Build and Test on dev#* branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,16 @@
 name: Build and Test
 on:
   push:
-    branches: [master, dev]
+    branches:
+      - master
+      - dev
+      # Stacked / feature branches (e.g. dev#536, dev#536-getter-leak-fix) — must quote # for YAML
+      - "dev#*"
   pull_request:
-    branches: [master, dev]
+    branches:
+      - master
+      - dev
+      - "dev#*"
 
 jobs:
   detect-changes:


### PR DESCRIPTION
Runs the **Build and Test** workflow for pushes and pull requests targeting branches that match `dev#*` (e.g. `dev#536`, stacked PRs like #817).

Without this, only `master` and `dev` triggered CI; PRs into feature branches had no checks.

**Merge this to `dev` first** so stacked PRs pick up the workflow from the default integration branch.

Made with Cursor