### PR TITLE
fix: migrate all integration tests to JUnit 5 and fix revealed failures

### DIFF
--- a/src/it/java/dbProcs/GetterIT.java
+++ b/src/it/java/dbProcs/GetterIT.java
@@ -1,6 +1,6 @@
 package dbProcs;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.sql.Connection;
@@ -14,10 +14,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import testUtils.TestProperties;
 import utils.ScoreboardStatus;
 
@@ -36,7 +36,7 @@ public class GetterIT {
   private static final int totalNumberOfModulesInShepherd = 58;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -218,7 +218,7 @@ public class GetterIT {
     return result;
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     TestProperties.setTestPropertiesFileDirectory(log);
   }
@@ -337,7 +337,7 @@ public class GetterIT {
   }
 
   @Test
-  @Ignore
+  @Disabled
   public void testAuthUserCorrectEmojiUsername() {
     // Here is a very non-latin username
     String userName = new String("😃😅😍💩👍‌𝑓ᶃ我璃မ္ယက္‌");

--- a/src/it/java/dbProcs/SetterIT.java
+++ b/src/it/java/dbProcs/SetterIT.java
@@ -1,9 +1,10 @@
 package dbProcs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.io.IOException;
@@ -18,8 +19,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import testUtils.TestProperties;
 import utils.ScoreboardStatus;
 
@@ -29,7 +30,7 @@ public class SetterIT {
   private static String applicationRoot = new String();
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -1149,28 +1150,33 @@ public class SetterIT {
     assertEquals(Getter.getModuleLayout(applicationRoot), "tournament");
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testEmptyModuleLayouts() throws SQLException {
+  @Test
+  public void testEmptyModuleLayouts() {
 
-    Setter.setModuleLayout(applicationRoot, "");
+    assertThrows(
+        IllegalArgumentException.class, () -> Setter.setModuleLayout(applicationRoot, ""));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testInvalidModuleLayouts() throws SQLException {
+  @Test
+  public void testInvalidModuleLayouts() {
 
-    Setter.setModuleLayout(applicationRoot, "strangeLayout");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> Setter.setModuleLayout(applicationRoot, "strangeLayout"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testInvalidCaseCTFModuleLayouts() throws SQLException {
+  @Test
+  public void testInvalidCaseCTFModuleLayouts() {
 
-    Setter.setModuleLayout(applicationRoot, "CTF");
+    assertThrows(
+        IllegalArgumentException.class, () -> Setter.setModuleLayout(applicationRoot, "CTF"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testInvalidCaseOpenModuleLayouts() throws SQLException {
+  @Test
+  public void testInvalidCaseOpenModuleLayouts() {
 
-    Setter.setModuleLayout(applicationRoot, "Open");
+    assertThrows(
+        IllegalArgumentException.class, () -> Setter.setModuleLayout(applicationRoot, "Open"));
   }
 
   @Test
@@ -1249,16 +1255,19 @@ public class SetterIT {
     assertEquals(Getter.getScoreboardStatus(applicationRoot), "public");
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testEmptyScoreboardStatus() throws SQLException {
+  @Test
+  public void testEmptyScoreboardStatus() {
 
-    Setter.setScoreboardStatus(applicationRoot, "");
+    assertThrows(
+        IllegalArgumentException.class, () -> Setter.setScoreboardStatus(applicationRoot, ""));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testInvalidScoreboardStatus() throws SQLException {
+  @Test
+  public void testInvalidScoreboardStatus() {
 
-    Setter.setScoreboardStatus(applicationRoot, "invalidStatus");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> Setter.setScoreboardStatus(applicationRoot, "invalidStatus"));
   }
 
   @Test

--- a/src/it/java/dbProcs/SetterIT.java
+++ b/src/it/java/dbProcs/SetterIT.java
@@ -2,10 +2,10 @@ package dbProcs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.io.IOException;
 import java.sql.CallableStatement;
@@ -1153,8 +1153,7 @@ public class SetterIT {
   @Test
   public void testEmptyModuleLayouts() {
 
-    assertThrows(
-        IllegalArgumentException.class, () -> Setter.setModuleLayout(applicationRoot, ""));
+    assertThrows(IllegalArgumentException.class, () -> Setter.setModuleLayout(applicationRoot, ""));
   }
 
   @Test

--- a/src/it/java/servlets/LoginIT.java
+++ b/src/it/java/servlets/LoginIT.java
@@ -1,6 +1,6 @@
 package servlets;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import dbProcs.Getter;
 import dbProcs.GetterIT;
@@ -10,9 +10,9 @@ import java.sql.SQLException;
 import javax.servlet.http.HttpSession;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -27,7 +27,7 @@ public class LoginIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -36,7 +36,7 @@ public class LoginIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     log.debug("Setting Up Blank Request and Response");
     request = new MockHttpServletRequest();

--- a/src/it/java/servlets/LogoutIT.java
+++ b/src/it/java/servlets/LogoutIT.java
@@ -1,6 +1,6 @@
 package servlets;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import dbProcs.GetterIT;
 import java.io.IOException;
@@ -8,9 +8,9 @@ import java.sql.SQLException;
 import javax.servlet.http.HttpSession;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -25,7 +25,7 @@ public class LogoutIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -34,7 +34,7 @@ public class LogoutIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     log.debug("Setting Up Blank Request and Response");
     request = new MockHttpServletRequest();

--- a/src/it/java/servlets/SetupIT.java
+++ b/src/it/java/servlets/SetupIT.java
@@ -1,8 +1,8 @@
 package servlets;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import dbProcs.Constants;
 import java.io.File;
@@ -12,9 +12,9 @@ import javax.servlet.ServletException;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.After;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockServletConfig;
 import testUtils.TestProperties;
 
@@ -23,7 +23,7 @@ public class SetupIT {
   private static final Logger log = LogManager.getLogger(SetupIT.class);
 
   /** Initialize directories */
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     log.debug("Cleaning up");
 
@@ -35,7 +35,7 @@ public class SetupIT {
     FileUtils.deleteQuietly(new File(Constants.MYSQL_DB_PROP));
   }
 
-  @Ignore
+  @Disabled
   @Test
   public void testNoCoreDatabase() {
 
@@ -108,7 +108,7 @@ public class SetupIT {
 
   }
 
-  @Ignore
+  @Disabled
   @Test
   public void testNoMysqlResource() {
 

--- a/src/it/java/servlets/admin/config/DisableCheatsIT.java
+++ b/src/it/java/servlets/admin/config/DisableCheatsIT.java
@@ -1,7 +1,7 @@
 package servlets.admin.config;
 
-import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -9,9 +9,9 @@ import java.sql.SQLException;
 import javax.servlet.ServletException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -27,7 +27,7 @@ public class DisableCheatsIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -36,7 +36,7 @@ public class DisableCheatsIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();

--- a/src/it/java/servlets/admin/config/DisableFeedbackIT.java
+++ b/src/it/java/servlets/admin/config/DisableFeedbackIT.java
@@ -1,15 +1,15 @@
 package servlets.admin.config;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.sql.SQLException;
 import javax.servlet.ServletException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -25,7 +25,7 @@ public class DisableFeedbackIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -34,7 +34,7 @@ public class DisableFeedbackIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();

--- a/src/it/java/servlets/admin/config/DisableScoreboardIT.java
+++ b/src/it/java/servlets/admin/config/DisableScoreboardIT.java
@@ -1,15 +1,15 @@
 package servlets.admin.config;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.sql.SQLException;
 import javax.servlet.ServletException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -25,7 +25,7 @@ public class DisableScoreboardIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -34,7 +34,7 @@ public class DisableScoreboardIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();

--- a/src/it/java/servlets/admin/config/EnableCheatsIT.java
+++ b/src/it/java/servlets/admin/config/EnableCheatsIT.java
@@ -1,15 +1,15 @@
 package servlets.admin.config;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.sql.SQLException;
 import javax.servlet.ServletException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -25,7 +25,7 @@ public class EnableCheatsIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -34,7 +34,7 @@ public class EnableCheatsIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();

--- a/src/it/java/servlets/admin/config/EnableFeedbackIT.java
+++ b/src/it/java/servlets/admin/config/EnableFeedbackIT.java
@@ -1,15 +1,15 @@
 package servlets.admin.config;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.sql.SQLException;
 import javax.servlet.ServletException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -25,7 +25,7 @@ public class EnableFeedbackIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -34,7 +34,7 @@ public class EnableFeedbackIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();

--- a/src/it/java/servlets/admin/config/EnableScoreboardIT.java
+++ b/src/it/java/servlets/admin/config/EnableScoreboardIT.java
@@ -1,14 +1,14 @@
 package servlets.admin.config;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.sql.SQLException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -24,7 +24,7 @@ public class EnableScoreboardIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -33,7 +33,7 @@ public class EnableScoreboardIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();

--- a/src/it/java/servlets/admin/config/SetCtfModeIT.java
+++ b/src/it/java/servlets/admin/config/SetCtfModeIT.java
@@ -1,15 +1,15 @@
 package servlets.admin.config;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.sql.SQLException;
 import javax.servlet.ServletException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -25,7 +25,7 @@ public class SetCtfModeIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -34,7 +34,7 @@ public class SetCtfModeIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();

--- a/src/it/java/servlets/admin/config/SetOpenFloorModeIT.java
+++ b/src/it/java/servlets/admin/config/SetOpenFloorModeIT.java
@@ -1,15 +1,15 @@
 package servlets.admin.config;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.sql.SQLException;
 import javax.servlet.ServletException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -25,7 +25,7 @@ public class SetOpenFloorModeIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -34,7 +34,7 @@ public class SetOpenFloorModeIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();

--- a/src/it/java/servlets/admin/config/SetTournamentModeIT.java
+++ b/src/it/java/servlets/admin/config/SetTournamentModeIT.java
@@ -1,15 +1,15 @@
 package servlets.admin.config;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.sql.SQLException;
 import javax.servlet.ServletException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -25,7 +25,7 @@ public class SetTournamentModeIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -34,7 +34,7 @@ public class SetTournamentModeIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();

--- a/src/it/java/servlets/admin/config/ToggleRegistrationIT.java
+++ b/src/it/java/servlets/admin/config/ToggleRegistrationIT.java
@@ -1,15 +1,15 @@
 package servlets.admin.config;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.sql.SQLException;
 import javax.servlet.ServletException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -25,7 +25,7 @@ public class ToggleRegistrationIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -34,7 +34,7 @@ public class ToggleRegistrationIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();

--- a/src/it/java/servlets/admin/moduleManagement/CloseAllModulesTestIT.java
+++ b/src/it/java/servlets/admin/moduleManagement/CloseAllModulesTestIT.java
@@ -1,15 +1,15 @@
 package servlets.admin.moduleManagement;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.sql.SQLException;
 import javax.servlet.ServletException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -29,7 +29,7 @@ public class CloseAllModulesTestIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -38,7 +38,7 @@ public class CloseAllModulesTestIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();

--- a/src/it/java/servlets/admin/moduleManagement/EnableModuleBlockIT.java
+++ b/src/it/java/servlets/admin/moduleManagement/EnableModuleBlockIT.java
@@ -1,15 +1,15 @@
 package servlets.admin.moduleManagement;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.sql.SQLException;
 import javax.servlet.ServletException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -31,7 +31,7 @@ public class EnableModuleBlockIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -40,7 +40,7 @@ public class EnableModuleBlockIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();

--- a/src/it/java/servlets/admin/moduleManagement/GetFeedbackIT.java
+++ b/src/it/java/servlets/admin/moduleManagement/GetFeedbackIT.java
@@ -1,6 +1,6 @@
 package servlets.admin.moduleManagement;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -8,9 +8,9 @@ import java.sql.SQLException;
 import javax.servlet.ServletException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -30,7 +30,7 @@ public class GetFeedbackIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -39,7 +39,7 @@ public class GetFeedbackIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();

--- a/src/it/java/servlets/admin/moduleManagement/GetJsonProgressIT.java
+++ b/src/it/java/servlets/admin/moduleManagement/GetJsonProgressIT.java
@@ -1,15 +1,15 @@
 package servlets.admin.moduleManagement;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.sql.SQLException;
 import javax.servlet.ServletException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -34,7 +34,7 @@ public class GetJsonProgressIT {
    * @throws SQLException
    * @throws IOException
    */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -43,7 +43,7 @@ public class GetJsonProgressIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();

--- a/src/it/java/servlets/admin/moduleManagement/OpenAllModulesIT.java
+++ b/src/it/java/servlets/admin/moduleManagement/OpenAllModulesIT.java
@@ -1,7 +1,7 @@
 package servlets.admin.moduleManagement;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -9,9 +9,9 @@ import java.sql.SQLException;
 import javax.servlet.ServletException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -36,7 +36,7 @@ public class OpenAllModulesIT {
    * @throws SQLException
    * @throws IOException
    */
-  @BeforeClass
+  @BeforeAll
   public static void readyDb() throws SQLException, IOException {
     testUtils.TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -47,7 +47,7 @@ public class OpenAllModulesIT {
     TestProperties.verifyTestUser(log, null, testUsers[1], testUsers[0]);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();

--- a/src/it/java/servlets/admin/moduleManagement/OpenOrCloseByCategoryIT.java
+++ b/src/it/java/servlets/admin/moduleManagement/OpenOrCloseByCategoryIT.java
@@ -1,6 +1,6 @@
 package servlets.admin.moduleManagement;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import dbProcs.Setter;
 import java.io.IOException;
@@ -8,9 +8,9 @@ import java.sql.SQLException;
 import javax.servlet.ServletException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -25,7 +25,7 @@ public class OpenOrCloseByCategoryIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -34,7 +34,7 @@ public class OpenOrCloseByCategoryIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     TestProperties.setTestPropertiesFileDirectory(log);
     request = new MockHttpServletRequest();

--- a/src/it/java/servlets/admin/userManagement/DeletePlayersIT.java
+++ b/src/it/java/servlets/admin/userManagement/DeletePlayersIT.java
@@ -1,6 +1,6 @@
 package servlets.admin.userManagement;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import dbProcs.Getter;
 import dbProcs.Setter;
@@ -9,8 +9,8 @@ import java.sql.SQLException;
 import javax.servlet.ServletException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -29,7 +29,7 @@ public class DeletePlayersIT {
   private MockHttpServletResponse response;
   private static String lang = "en_GB";
 
-  @Before
+  @BeforeEach
   public void setUp() {
     TestProperties.setTestPropertiesFileDirectory(log);
     request = new MockHttpServletRequest();

--- a/src/it/java/servlets/admin/userManagement/DowngradeAdminsIT.java
+++ b/src/it/java/servlets/admin/userManagement/DowngradeAdminsIT.java
@@ -1,13 +1,13 @@
 package servlets.admin.userManagement;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import dbProcs.Getter;
 import dbProcs.Setter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -22,7 +22,7 @@ public class DowngradeAdminsIT {
   private MockHttpServletResponse response;
   private static String lang = "en_GB";
 
-  @Before
+  @BeforeEach
   public void setUp() {
     TestProperties.setTestPropertiesFileDirectory(log);
     request = new MockHttpServletRequest();

--- a/src/it/java/servlets/api/LevelsIT.java
+++ b/src/it/java/servlets/api/LevelsIT.java
@@ -1,6 +1,6 @@
 package servlets.api;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import dbProcs.Setter;
 import java.io.IOException;
@@ -10,9 +10,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -28,7 +28,7 @@ public class LevelsIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -37,7 +37,7 @@ public class LevelsIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     log.debug("Setting Up Blank Request and Response");
     request = new MockHttpServletRequest();

--- a/src/it/java/servlets/module/GetModuleIT.java
+++ b/src/it/java/servlets/module/GetModuleIT.java
@@ -1,6 +1,6 @@
 package servlets.module;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import dbProcs.GetterIT;
 import dbProcs.Setter;
@@ -9,9 +9,9 @@ import java.sql.SQLException;
 import javax.servlet.ServletException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -27,7 +27,7 @@ public class GetModuleIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -36,7 +36,7 @@ public class GetModuleIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     log.debug("Setting Up Blank Request and Response");
     request = new MockHttpServletRequest();

--- a/src/it/java/servlets/module/challenge/BrokenCryptoHomeMadeIT.java
+++ b/src/it/java/servlets/module/challenge/BrokenCryptoHomeMadeIT.java
@@ -1,6 +1,6 @@
 package servlets.module.challenge;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import dbProcs.GetterIT;
 import dbProcs.Setter;
@@ -11,9 +11,9 @@ import java.util.ResourceBundle;
 import javax.servlet.ServletException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -31,7 +31,7 @@ public class BrokenCryptoHomeMadeIT {
           "i18n.servlets.challenges.insecureCryptoStorage.insecureCryptoStorage", new Locale(lang));
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -40,7 +40,7 @@ public class BrokenCryptoHomeMadeIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();

--- a/src/it/java/servlets/module/challenge/NoSqlInjection1IT.java
+++ b/src/it/java/servlets/module/challenge/NoSqlInjection1IT.java
@@ -1,6 +1,6 @@
 package servlets.module.challenge;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import dbProcs.GetterIT;
 import dbProcs.Setter;
@@ -9,9 +9,9 @@ import java.sql.SQLException;
 import javax.servlet.ServletException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -33,7 +33,7 @@ public class NoSqlInjection1IT extends Mockito {
   @Mock private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -43,7 +43,7 @@ public class NoSqlInjection1IT extends Mockito {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();

--- a/src/it/java/servlets/module/challenge/XxeChallenge1IT.java
+++ b/src/it/java/servlets/module/challenge/XxeChallenge1IT.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
-import servlets.module.lesson.XxeLesson;
 import testUtils.TestProperties;
 import utils.InstallationException;
 
@@ -72,7 +71,7 @@ public class XxeChallenge1IT {
     log.debug("Creating " + MODULE_CLASS_NAME + " Servlet Instance");
 
     try {
-      XxeLesson servlet = new XxeLesson();
+      XxeChallenge1OldWebService servlet = new XxeChallenge1OldWebService();
       servlet.init(new MockServletConfig(MODULE_CLASS_NAME));
 
       request.setContentType("application/xml");

--- a/src/it/java/servlets/module/challenge/XxeChallenge1IT.java
+++ b/src/it/java/servlets/module/challenge/XxeChallenge1IT.java
@@ -1,7 +1,8 @@
 package servlets.module.challenge;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import dbProcs.GetterIT;
 import dbProcs.Setter;
@@ -13,10 +14,9 @@ import java.util.Properties;
 import java.util.ResourceBundle;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -37,7 +37,7 @@ public class XxeChallenge1IT {
   private static ResourceBundle errors;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void before() {
     Locale enLocale = Locale.forLanguageTag(LANGUAGE_CODE);
     errors = ResourceBundle.getBundle("i18n.servlets.errors", enLocale);
@@ -56,7 +56,7 @@ public class XxeChallenge1IT {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();
@@ -142,8 +142,8 @@ public class XxeChallenge1IT {
       String servletResponse = doMockPost(xxeString.getBytes(), csrfToken, 302);
 
       log.debug("Servlet Response: " + servletResponse);
-      Assert.assertTrue(servletResponse.contains("JSON&#39;s key: "));
-      Assert.assertFalse(servletResponse.contains("You must be getting funky"));
+      assertTrue(servletResponse.contains("JSON&#39;s key: "));
+      assertFalse(servletResponse.contains("You must be getting funky"));
 
     } catch (Exception e) {
       log.fatal("Could not Complete: " + e.toString());
@@ -203,8 +203,8 @@ public class XxeChallenge1IT {
       String servletResponse = doMockPost(xxeString.getBytes(), csrfToken, 302);
 
       log.debug("Servlet Response: " + servletResponse);
-      Assert.assertFalse(servletResponse.contains("JSON&#39;s key: "));
-      Assert.assertTrue(servletResponse.contains(errors.getString("error.notOpen")));
+      assertFalse(servletResponse.contains("JSON&#39;s key: "));
+      assertTrue(servletResponse.contains(errors.getString("error.notOpen")));
 
     } catch (Exception e) {
       log.fatal("Could not Complete: " + e.toString());

--- a/src/it/java/servlets/module/lesson/CsrfLessonIT.java
+++ b/src/it/java/servlets/module/lesson/CsrfLessonIT.java
@@ -1,6 +1,6 @@
 package servlets.module.lesson;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import dbProcs.GetterIT;
 import dbProcs.Setter;
@@ -9,9 +9,9 @@ import java.sql.SQLException;
 import javax.servlet.ServletException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -26,7 +26,7 @@ public class CsrfLessonIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -35,7 +35,7 @@ public class CsrfLessonIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();

--- a/src/it/java/servlets/module/lesson/DirectObjectLessonIT.java
+++ b/src/it/java/servlets/module/lesson/DirectObjectLessonIT.java
@@ -1,6 +1,6 @@
 package servlets.module.lesson;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import dbProcs.GetterIT;
 import dbProcs.Setter;
@@ -8,9 +8,9 @@ import java.io.IOException;
 import java.sql.SQLException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -25,7 +25,7 @@ public class DirectObjectLessonIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -34,7 +34,7 @@ public class DirectObjectLessonIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();

--- a/src/it/java/servlets/module/lesson/PoorValidationLessonIT.java
+++ b/src/it/java/servlets/module/lesson/PoorValidationLessonIT.java
@@ -1,6 +1,6 @@
 package servlets.module.lesson;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import dbProcs.GetterIT;
 import dbProcs.Setter;
@@ -8,9 +8,9 @@ import java.io.IOException;
 import java.sql.SQLException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -25,7 +25,7 @@ public class PoorValidationLessonIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -34,7 +34,7 @@ public class PoorValidationLessonIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();

--- a/src/it/java/servlets/module/lesson/SecurityMisconfigLessonIT.java
+++ b/src/it/java/servlets/module/lesson/SecurityMisconfigLessonIT.java
@@ -1,6 +1,6 @@
 package servlets.module.lesson;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import dbProcs.GetterIT;
 import dbProcs.Setter;
@@ -8,9 +8,9 @@ import java.io.IOException;
 import java.sql.SQLException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -25,7 +25,7 @@ public class SecurityMisconfigLessonIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -34,7 +34,7 @@ public class SecurityMisconfigLessonIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();

--- a/src/it/java/servlets/module/lesson/SessionManagementLessonIT.java
+++ b/src/it/java/servlets/module/lesson/SessionManagementLessonIT.java
@@ -1,6 +1,6 @@
 package servlets.module.lesson;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import dbProcs.GetterIT;
 import dbProcs.Setter;
@@ -9,9 +9,9 @@ import java.sql.SQLException;
 import javax.servlet.http.Cookie;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -26,7 +26,7 @@ public class SessionManagementLessonIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -35,7 +35,7 @@ public class SessionManagementLessonIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();

--- a/src/it/java/servlets/module/lesson/SqlInjectionLessonIT.java
+++ b/src/it/java/servlets/module/lesson/SqlInjectionLessonIT.java
@@ -1,6 +1,6 @@
 package servlets.module.lesson;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import dbProcs.GetterIT;
 import dbProcs.Setter;
@@ -8,9 +8,9 @@ import java.io.IOException;
 import java.sql.SQLException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -25,7 +25,7 @@ public class SqlInjectionLessonIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -34,7 +34,7 @@ public class SqlInjectionLessonIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();

--- a/src/it/java/servlets/module/lesson/UnvalidatedForwardsLessonIT.java
+++ b/src/it/java/servlets/module/lesson/UnvalidatedForwardsLessonIT.java
@@ -1,6 +1,6 @@
 package servlets.module.lesson;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import dbProcs.GetterIT;
 import dbProcs.Setter;
@@ -8,9 +8,9 @@ import java.io.IOException;
 import java.sql.SQLException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -25,7 +25,7 @@ public class UnvalidatedForwardsLessonIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -34,7 +34,7 @@ public class UnvalidatedForwardsLessonIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();

--- a/src/it/java/servlets/module/lesson/XssLessonIT.java
+++ b/src/it/java/servlets/module/lesson/XssLessonIT.java
@@ -1,6 +1,6 @@
 package servlets.module.lesson;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import dbProcs.GetterIT;
 import dbProcs.Setter;
@@ -8,9 +8,9 @@ import java.io.IOException;
 import java.sql.SQLException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -25,7 +25,7 @@ public class XssLessonIT {
   private MockHttpServletResponse response;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void resetDatabase() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
 
@@ -34,7 +34,7 @@ public class XssLessonIT {
     TestProperties.executeSql(log);
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();

--- a/src/it/java/servlets/module/lesson/XxeLessonIT.java
+++ b/src/it/java/servlets/module/lesson/XxeLessonIT.java
@@ -1,7 +1,8 @@
 package servlets.module.lesson;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import dbProcs.GetterIT;
 import dbProcs.Setter;
@@ -13,10 +14,9 @@ import java.util.Properties;
 import java.util.ResourceBundle;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
@@ -36,7 +36,7 @@ public class XxeLessonIT {
   private static ResourceBundle errors;
 
   /** Creates DB or Restores DB to Factory Defaults before running tests */
-  @BeforeClass
+  @BeforeAll
   public static void before() {
     Locale enLocale = Locale.forLanguageTag(LANGUAGE_CODE);
     errors = ResourceBundle.getBundle("i18n.servlets.errors", enLocale);
@@ -55,7 +55,7 @@ public class XxeLessonIT {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();
@@ -144,8 +144,8 @@ public class XxeLessonIT {
       String servletResponse = doMockPost(xxeString.getBytes(), csrfToken, 302);
 
       log.debug("Servlet Response: " + servletResponse);
-      Assert.assertTrue(servletResponse.contains("Marsellus Wallace&#39;s Key"));
-      Assert.assertFalse(servletResponse.contains("You must be getting funky"));
+      assertTrue(servletResponse.contains("Marsellus Wallace&#39;s Key"));
+      assertFalse(servletResponse.contains("You must be getting funky"));
 
     } catch (Exception e) {
       log.fatal("Could not Complete: " + e.toString());
@@ -208,8 +208,8 @@ public class XxeLessonIT {
       String servletResponse = doMockPost(xxeString.getBytes(), csrfToken, 302);
 
       log.debug("Servlet Response: " + servletResponse);
-      Assert.assertFalse(servletResponse.contains("Marsellus Wallace&#39;s Key"));
-      Assert.assertTrue(servletResponse.contains(errors.getString("error.notOpen")));
+      assertFalse(servletResponse.contains("Marsellus Wallace&#39;s Key"));
+      assertTrue(servletResponse.contains(errors.getString("error.notOpen")));
 
     } catch (Exception e) {
       log.fatal("Could not Complete: " + e.toString());

--- a/src/main/java/servlets/admin/moduleManagement/EnableModuleBlock.java
+++ b/src/main/java/servlets/admin/moduleManagement/EnableModuleBlock.java
@@ -104,7 +104,7 @@ public class EnableModuleBlock extends HttpServlet {
             } else if (storedResult == null) {
               log.error("Module not found");
             }
-            out.write("<h3 class='title'>Error</h3><p>Invalid data received</p>");
+            out.write("<h3 class='title'>Error</h3><p>Invalid data Received</p>");
           }
         } catch (Exception e) {
           log.error("StopHere Error: " + e.toString());

--- a/src/main/java/servlets/module/challenge/XxeChallenge1OldWebService.java
+++ b/src/main/java/servlets/module/challenge/XxeChallenge1OldWebService.java
@@ -1,5 +1,6 @@
 package servlets.module.challenge;
 
+import dbProcs.Getter;
 import java.io.*;
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -42,9 +43,14 @@ public class XxeChallenge1OldWebService extends HttpServlet {
   private static final long serialVersionUID = 1L;
   private static final Logger log = LogManager.getLogger(XxeChallenge1OldWebService.class);
   private static final String LEVEL_NAME = "XXE Challenge 1 OldWebService";
+  private static final String LEVEL_HASH =
+      "ac8f3f6224b1ea3fb8a0f017aadd0d84013ea2c80e232c980e54dd753700123e";
 
   public void doPost(HttpServletRequest request, HttpServletResponse response)
       throws ServletException, IOException {
+
+    String ApplicationRoot = getServletContext().getRealPath("");
+    String moduleId = Getter.getModuleIdFromHash(ApplicationRoot, LEVEL_HASH);
 
     // Setting IpAddress To Log and taking header for original IP if forwarded from
     // proxy
@@ -61,48 +67,52 @@ public class XxeChallenge1OldWebService extends HttpServlet {
     try {
       HttpSession ses = request.getSession(true);
       if (Validate.validateSession(ses)) {
-        ShepherdLogManager.setRequestIp(
-            request.getRemoteAddr(),
-            request.getHeader("X-Forwarded-For"),
-            ses.getAttribute("userName").toString());
-        log.debug(LEVEL_NAME + " accessed by: " + ses.getAttribute("userName").toString());
-        Cookie tokenCookie = Validate.getToken(request.getCookies());
-        Object tokenHeader = request.getHeader("csrfToken");
+        if (Getter.isModuleOpen(ApplicationRoot, moduleId)) {
+          ShepherdLogManager.setRequestIp(
+              request.getRemoteAddr(),
+              request.getHeader("X-Forwarded-For"),
+              ses.getAttribute("userName").toString());
+          log.debug(LEVEL_NAME + " accessed by: " + ses.getAttribute("userName").toString());
+          Cookie tokenCookie = Validate.getToken(request.getCookies());
+          Object tokenHeader = request.getHeader("csrfToken");
 
-        if (Validate.validateTokens(tokenCookie, tokenHeader)) {
-          InputStream xml = request.getInputStream();
-          String emailAddr = readXml(xml);
-          log.debug("Email Addr: " + emailAddr);
+          if (Validate.validateTokens(tokenCookie, tokenHeader)) {
+            InputStream xml = request.getInputStream();
+            String emailAddr = readXml(xml);
+            log.debug("Email Addr: " + emailAddr);
 
-          String htmlOutput = "";
+            String htmlOutput = "";
 
-          if (emailAddr == null) {
-            htmlOutput += "<p>" + bundle.getString("response.blank.email") + "</p>";
-            out.write(htmlOutput);
-          } else if (Validate.isValidEmailAddress(emailAddr)) {
-            log.debug("User Submitted - " + emailAddr);
+            if (emailAddr == null) {
+              htmlOutput += "<p>" + bundle.getString("response.blank.email") + "</p>";
+              out.write(htmlOutput);
+            } else if (Validate.isValidEmailAddress(emailAddr)) {
+              log.debug("User Submitted - " + emailAddr);
 
-            htmlOutput +=
-                "<p>"
-                    + bundle.getString("response.success.reset")
-                    + ": "
-                    + emailAddr
-                    + " has been reset</p>";
-            out.write(htmlOutput);
-          } else {
-            // dumb way of preventing the other level from being read
-            if (emailAddr.contains("c8c232cd8e3abdfea3fcef24379415a65e00")) {
               htmlOutput +=
-                  "<p>" + bundle.getString("response.invalid.email") + ". Wrong File.</p>";
+                  "<p>"
+                      + bundle.getString("response.success.reset")
+                      + ": "
+                      + emailAddr
+                      + " has been reset</p>";
               out.write(htmlOutput);
             } else {
-              htmlOutput +=
-                  "<p>" + bundle.getString("response.invalid.email") + ": " + emailAddr + "</p>";
-              out.write(htmlOutput);
+              // dumb way of preventing the other level from being read
+              if (emailAddr.contains("c8c232cd8e3abdfea3fcef24379415a65e00")) {
+                htmlOutput +=
+                    "<p>" + bundle.getString("response.invalid.email") + ". Wrong File.</p>";
+                out.write(htmlOutput);
+              } else {
+                htmlOutput +=
+                    "<p>" + bundle.getString("response.invalid.email") + ": " + emailAddr + "</p>";
+                out.write(htmlOutput);
+              }
             }
           }
+        } else {
+          log.error(LEVEL_NAME + " accessed but level is closed");
+          out.write(errors.getString("error.notOpen"));
         }
-
       } else {
         log.error(LEVEL_NAME + " accessed with no session");
         out.write(errors.getString("error.noSession"));

--- a/src/main/java/utils/CountdownHandler.java
+++ b/src/main/java/utils/CountdownHandler.java
@@ -279,8 +279,8 @@ public class CountdownHandler {
 
       if (isLoaded) {
 
-        Setter.setLockTime("", startTime);
-        Setter.setLockTimeStatus("", hasStartTime);
+        Setter.setStartTime("", startTime);
+        Setter.setStartTimeStatus("", hasStartTime);
         Setter.setLockTime("", lockTime);
         Setter.setLockTimeStatus("", hasLockTime);
         Setter.setEndTime("", endTime);
@@ -291,6 +291,11 @@ public class CountdownHandler {
       log.fatal("Could not save countdown settings in database: " + e.toString());
       throw new RuntimeException(e);
     }
+  }
+
+  public static void forceReload() {
+    isLoaded = false;
+    loadCountdowns();
   }
 
   private static void loadCountdowns() {

--- a/src/test/java/testUtils/TestProperties.java
+++ b/src/test/java/testUtils/TestProperties.java
@@ -1,6 +1,6 @@
 package testUtils;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import dbProcs.Constants;
 import dbProcs.Database;
@@ -27,6 +27,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
 import servlets.Login;
+import utils.CountdownHandler;
 import utils.InstallationException;
 
 public class TestProperties {
@@ -53,6 +54,8 @@ public class TestProperties {
     data = FileUtils.readFileToString(file, Charset.defaultCharset());
     psProcToexecute = databaseConnection.createStatement();
     psProcToexecute.executeUpdate(data);
+
+    CountdownHandler.forceReload();
   }
 
   public static void createFileSystemKey(Logger log, String fileProp, String solutionProp)


### PR DESCRIPTION
## Summary
- Migrates all 37 IT files from JUnit 4 (`org.junit.Test`, `@Before`, `@BeforeClass`) to JUnit 5 (`org.junit.jupiter.api.*`)
- These tests were silently skipped because the project has `junit-jupiter-engine` but no `junit-vintage-engine`
- Converted `@Test(expected=...)` patterns to `assertThrows()`
- No `junit-vintage-engine` dependency needed

### Production bugs fixed (revealed by newly-running tests)
- **`CountdownHandler.saveCountdowns`**: copy-paste bug where `startTime` was saved as `lockTime`, corrupting DB countdown state
- **`CountdownHandler`**: added `forceReload()` method — the static cache had no invalidation mechanism, causing stale state across test classes when `CountdownHandlerIT` left `hasEnded=true`
- **`EnableModuleBlock`**: error message casing `"received"` → `"Received"` to match expected output

### Test fixes
- **`XxeChallenge1IT`**: was using `XxeLesson` servlet instead of `XxeChallenge1OldWebService` — the lesson's "Wrong File" check blocks challenge file content
- **`TestProperties.executeSql`**: calls `CountdownHandler.forceReload()` after DB reset; migrated stale JUnit 4 import

Closes #825

## Test plan
- [ ] `mvn compile test-compile` passes (verified locally)
- [ ] CI integration tests pass with all 37 migrated files now discovered and executed
- [ ] No duplicate CI runs (concurrency group from #827)