### PR TITLE
ci: add concurrency group to deduplicate workflow runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,13 +4,15 @@ on:
     branches:
       - master
       - dev
-      # Stacked / feature branches (e.g. dev#536, dev#536-getter-leak-fix) — must quote # for YAML
       - "dev#*"
   pull_request:
     branches:
       - master
       - dev
-      - "dev#*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   detect-changes:


### PR DESCRIPTION
## Summary
- Adds a `concurrency` group to the Build and Test workflow so that pushing to a feature branch with an open PR doesn't trigger duplicate runs (one from `push`, one from `pull_request`)
- `cancel-in-progress: true` cancels stale runs when new commits are pushed

## Test plan
- [ ] Push to a branch with an open PR and verify only one workflow run proceeds