### PR TITLE
fix: return core DB connections to pool from Setter (stacked on #816)

### DIFF
--- a/src/it/java/dbProcs/GetterAuthIT.java
+++ b/src/it/java/dbProcs/GetterAuthIT.java
@@ -28,7 +28,8 @@ public class GetterAuthIT {
   public static void setup() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
     TestProperties.createMysqlResource();
-    TestProperties.executeSql(log);
+    TestProperties.ensureSchemaReady(log);
+    TestProperties.reseedTestData();
     try {
       ConnectionPool.initialize();
       Getter.getClassCount(applicationRoot);

--- a/src/it/java/dbProcs/GetterCorePoolLeakIT.java
+++ b/src/it/java/dbProcs/GetterCorePoolLeakIT.java
@@ -29,7 +29,8 @@ public class GetterCorePoolLeakIT {
   public static void setup() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
     TestProperties.createMysqlResource();
-    TestProperties.executeSql(log);
+    TestProperties.ensureSchemaReady(log);
+    TestProperties.reseedTestData();
     try {
       ConnectionPool.initialize();
       Getter.getClassCount(applicationRoot);

--- a/src/it/java/dbProcs/GetterCorePoolLeakIT.java
+++ b/src/it/java/dbProcs/GetterCorePoolLeakIT.java
@@ -1,5 +1,6 @@
 package dbProcs;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -21,9 +22,6 @@ public class GetterCorePoolLeakIT {
   private static final Logger log = LogManager.getLogger(GetterCorePoolLeakIT.class);
   private static boolean databaseAvailable = false;
   private static final String applicationRoot = "";
-
-  /** Must stay within configured core pool max (see database.properties / ConnectionPool). */
-  private static final int MAX_ALLOWED_ACTIVE = 32;
 
   @BeforeAll
   public static void setup() throws IOException, SQLException {
@@ -50,6 +48,12 @@ public class GetterCorePoolLeakIT {
     assumeTrue(databaseAvailable, "Database not available");
   }
 
+  /**
+   * The loop is serial, so a non-leaking pool must return active count to the pre-call baseline
+   * after every iteration. Asserting equality with baseline (typically 0) detects leaks
+   * deterministically — a hardcoded ceiling can still pass while the pool saturates (e.g. with
+   * coreMax=20 and Hikari's 5s acquire timeout, callers throw long before active reaches 32).
+   */
   @Test
   public void repeatedAuthUserDoesNotExhaustCorePool() {
     requireDatabase();
@@ -65,8 +69,13 @@ public class GetterCorePoolLeakIT {
         "GetterCorePoolLeakIT: baseline active={}, after 500 authUser calls active={}",
         baseline,
         active);
-    assertTrue(
-        active <= MAX_ALLOWED_ACTIVE,
-        "Core pool active connections should stay bounded; got " + active);
+    assertEquals(
+        baseline,
+        active,
+        "Core pool active connections should return to baseline after a serial loop; got "
+            + active
+            + " (baseline "
+            + baseline
+            + ")");
   }
 }

--- a/src/it/java/dbProcs/SetterCorePoolLeakIT.java
+++ b/src/it/java/dbProcs/SetterCorePoolLeakIT.java
@@ -1,5 +1,6 @@
 package dbProcs;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -21,9 +22,6 @@ public class SetterCorePoolLeakIT {
   private static final Logger log = LogManager.getLogger(SetterCorePoolLeakIT.class);
   private static boolean databaseAvailable = false;
   private static final String applicationRoot = "";
-
-  /** Must stay within configured core pool max (see database.properties / ConnectionPool). */
-  private static final int MAX_ALLOWED_ACTIVE = 32;
 
   @BeforeAll
   public static void setup() throws IOException, SQLException {
@@ -55,6 +53,10 @@ public class SetterCorePoolLeakIT {
    * procedure, returns. With a nonexistent userId the procedure is a no-op, so we can hammer it
    * safely. Pre-fix, every iteration would leak a connection on the success path's manual
    * closeConnection call (and on every exception path).
+   *
+   * <p>The loop is serial, so a non-leaking pool must return active count to the pre-call baseline
+   * after every iteration. Asserting equality with baseline (typically 0) detects leaks
+   * deterministically — a hardcoded ceiling can still pass while the pool saturates.
    */
   @Test
   public void repeatedResetBadSubmissionDoesNotExhaustCorePool() {
@@ -71,9 +73,14 @@ public class SetterCorePoolLeakIT {
         "SetterCorePoolLeakIT: baseline active={}, after 500 resetBadSubmission calls active={}",
         baseline,
         active);
-    assertTrue(
-        active <= MAX_ALLOWED_ACTIVE,
-        "Core pool active connections should stay bounded; got " + active);
+    assertEquals(
+        baseline,
+        active,
+        "Core pool active connections should return to baseline after a serial loop; got "
+            + active
+            + " (baseline "
+            + baseline
+            + ")");
   }
 
   /**
@@ -95,8 +102,13 @@ public class SetterCorePoolLeakIT {
         "SetterCorePoolLeakIT: baseline active={}, after 500 suspendUser calls active={}",
         baseline,
         active);
-    assertTrue(
-        active <= MAX_ALLOWED_ACTIVE,
-        "Core pool active connections should stay bounded; got " + active);
+    assertEquals(
+        baseline,
+        active,
+        "Core pool active connections should return to baseline after a serial loop; got "
+            + active
+            + " (baseline "
+            + baseline
+            + ")");
   }
 }

--- a/src/it/java/dbProcs/SetterCorePoolLeakIT.java
+++ b/src/it/java/dbProcs/SetterCorePoolLeakIT.java
@@ -51,8 +51,9 @@ public class SetterCorePoolLeakIT {
   /**
    * resetBadSubmission is a representative core write: it borrows a connection, runs a stored
    * procedure, returns. With a nonexistent userId the procedure is a no-op, so we can hammer it
-   * safely. Pre-fix, every iteration would leak a connection on the success path's manual
-   * closeConnection call (and on every exception path).
+   * safely. Pre-fix, the success path called Database.closeConnection and returned the connection,
+   * but any thrown SQLException (or early return) skipped that line and leaked the connection —
+   * exactly the failure mode the try-with-resources conversion fixes.
    *
    * <p>The loop is serial, so a non-leaking pool must return active count to the pre-call baseline
    * after every iteration. Asserting equality with baseline (typically 0) detects leaks

--- a/src/it/java/dbProcs/SetterCorePoolLeakIT.java
+++ b/src/it/java/dbProcs/SetterCorePoolLeakIT.java
@@ -1,0 +1,102 @@
+package dbProcs;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import testUtils.TestProperties;
+
+/**
+ * Verifies that high-frequency Setter core DB calls return connections to the Hikari pool (no
+ * unbounded growth in active connections). Mirrors GetterCorePoolLeakIT.
+ */
+public class SetterCorePoolLeakIT {
+
+  private static final Logger log = LogManager.getLogger(SetterCorePoolLeakIT.class);
+  private static boolean databaseAvailable = false;
+  private static final String applicationRoot = "";
+
+  /** Must stay within configured core pool max (see database.properties / ConnectionPool). */
+  private static final int MAX_ALLOWED_ACTIVE = 32;
+
+  @BeforeAll
+  public static void setup() throws IOException, SQLException {
+    TestProperties.setTestPropertiesFileDirectory(log);
+    TestProperties.createMysqlResource();
+    TestProperties.ensureSchemaReady(log);
+    TestProperties.reseedTestData();
+    try {
+      ConnectionPool.initialize();
+      Getter.getClassCount(applicationRoot);
+      databaseAvailable = ConnectionPool.isInitialized();
+    } catch (Exception e) {
+      log.warn("Database not available for SetterCorePoolLeakIT: {}", e.getMessage());
+      databaseAvailable = false;
+    }
+  }
+
+  @AfterAll
+  public static void cleanup() {
+    ConnectionPool.shutdown();
+  }
+
+  private void requireDatabase() {
+    assumeTrue(databaseAvailable, "Database not available");
+  }
+
+  /**
+   * resetBadSubmission is a representative core write: it borrows a connection, runs a stored
+   * procedure, returns. With a nonexistent userId the procedure is a no-op, so we can hammer it
+   * safely. Pre-fix, every iteration would leak a connection on the success path's manual
+   * closeConnection call (and on every exception path).
+   */
+  @Test
+  public void repeatedResetBadSubmissionDoesNotExhaustCorePool() {
+    requireDatabase();
+    int baseline = ConnectionPool.getCoreActiveConnections();
+    assertTrue(baseline >= 0);
+
+    for (int i = 0; i < 500; i++) {
+      Setter.resetBadSubmission(applicationRoot, "nonexistent_pool_leak_user_" + i);
+    }
+
+    int active = ConnectionPool.getCoreActiveConnections();
+    log.debug(
+        "SetterCorePoolLeakIT: baseline active={}, after 500 resetBadSubmission calls active={}",
+        baseline,
+        active);
+    assertTrue(
+        active <= MAX_ALLOWED_ACTIVE,
+        "Core pool active connections should stay bounded; got " + active);
+  }
+
+  /**
+   * suspendUser exercises a different code path (the catch-and-return-false branch on most calls
+   * since the userId does not exist). Verifies the exception path also returns the connection.
+   */
+  @Test
+  public void repeatedSuspendUserDoesNotExhaustCorePool() {
+    requireDatabase();
+    int baseline = ConnectionPool.getCoreActiveConnections();
+    assertTrue(baseline >= 0);
+
+    for (int i = 0; i < 500; i++) {
+      Setter.suspendUser(applicationRoot, "nonexistent_pool_leak_user_" + i, 1);
+    }
+
+    int active = ConnectionPool.getCoreActiveConnections();
+    log.debug(
+        "SetterCorePoolLeakIT: baseline active={}, after 500 suspendUser calls active={}",
+        baseline,
+        active);
+    assertTrue(
+        active <= MAX_ALLOWED_ACTIVE,
+        "Core pool active connections should stay bounded; got " + active);
+  }
+}

--- a/src/it/java/servlets/SetupIT.java
+++ b/src/it/java/servlets/SetupIT.java
@@ -158,7 +158,8 @@ public class SetupIT {
   public void isInstalled_cachesResult() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
     TestProperties.createMysqlResource();
-    TestProperties.executeSql(log);
+    TestProperties.ensureSchemaReady(log);
+    TestProperties.reseedTestData();
 
     boolean poolReady = false;
     try {
@@ -186,7 +187,8 @@ public class SetupIT {
   public void resetInstalledCache_allowsReevaluation() throws IOException, SQLException {
     TestProperties.setTestPropertiesFileDirectory(log);
     TestProperties.createMysqlResource();
-    TestProperties.executeSql(log);
+    TestProperties.ensureSchemaReady(log);
+    TestProperties.reseedTestData();
 
     boolean poolReady = false;
     try {

--- a/src/main/java/dbProcs/ConnectionPool.java
+++ b/src/main/java/dbProcs/ConnectionPool.java
@@ -2,6 +2,7 @@ package dbProcs;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -264,6 +265,19 @@ public class ConnectionPool {
   }
 
   /**
+   * Loads database properties if the file exists; otherwise returns an empty Properties object.
+   * Used by the challenge-connection path during first-time setup, when callers supply
+   * url/user/password as arguments and the on-disk file does not yet exist. All pool tuning
+   * properties have defaults, so an empty Properties object is safe.
+   */
+  private static Properties loadDatabasePropertiesIfPresent() {
+    if (!new File(Constants.MYSQL_DB_PROP).isFile()) {
+      return new Properties();
+    }
+    return loadDatabaseProperties();
+  }
+
+  /**
    * Gets a connection from the core database pool.
    *
    * @return A connection from the pool
@@ -314,7 +328,10 @@ public class ConnectionPool {
         challengePools.computeIfAbsent(
             poolKey,
             key -> {
-              Properties prop = loadDatabaseProperties();
+              // Tolerate missing database.properties: during first-time setup the file does
+              // not exist yet, but the caller already supplied url/user/password. Pool tuning
+              // falls back to defaults when properties are absent.
+              Properties prop = loadDatabasePropertiesIfPresent();
               return createDataSource(
                   jdbcUrl,
                   username,

--- a/src/main/java/dbProcs/Setter.java
+++ b/src/main/java/dbProcs/Setter.java
@@ -76,8 +76,7 @@ public class Setter {
     log.debug("*** Setter.classCreate ***");
 
     boolean result = false;
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       log.debug("Preparing classCreate call");
       CallableStatement callstmnt = conn.prepareCall("call classCreate(?, ?)");
@@ -86,7 +85,6 @@ public class Setter {
       log.debug("Executing classCreate");
       callstmnt.execute();
       result = true;
-      Database.closeConnection(conn);
 
     } catch (SQLException e) {
       log.error("classCreate Failure: " + e.toString());
@@ -104,15 +102,13 @@ public class Setter {
   public static boolean closeAllModules(String ApplicationRoot) {
     log.debug("*** Setter.closeAllModules ***");
     boolean result = false;
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       PreparedStatement callstmt =
           conn.prepareStatement("UPDATE modules SET moduleStatus = 'closed'");
       callstmt.execute();
       log.debug("All modules Set to closed");
       result = true;
-      Database.closeConnection(conn);
 
     } catch (SQLException e) {
       log.error("Could not close all modules: " + e.toString());
@@ -133,8 +129,7 @@ public class Setter {
     log.debug("*** Setter.incrementBadSubmission ***");
 
     boolean result = false;
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       log.debug("Prepairing bad Submission call");
       PreparedStatement callstmnt = conn.prepareCall("CALL userBadSubmission(?)");
@@ -142,7 +137,6 @@ public class Setter {
       log.debug("Executing userBadSubmission statement on id '" + userId + "'");
       callstmnt.execute();
       result = true;
-      Database.closeConnection(conn);
 
     } catch (SQLException e) {
       log.error("userBadSubmission Failure: " + e.toString());
@@ -162,8 +156,7 @@ public class Setter {
   public static boolean openAllModules(String ApplicationRoot, boolean unsafe) {
     log.debug("*** Setter.openAllModules ***");
     boolean result = false;
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       if (unsafe) {
         PreparedStatement callstmt =
@@ -178,7 +171,6 @@ public class Setter {
       }
 
       result = true;
-      Database.closeConnection(conn);
 
     } catch (SQLException e) {
       log.error("Could not open all modules: " + e.toString());
@@ -196,8 +188,7 @@ public class Setter {
   public static boolean openOnlyMobileCategories(String ApplicationRoot) {
     log.debug("*** Setter.openOnlyMobileCategories ***");
     boolean result = false;
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       PreparedStatement prepstmt =
           conn.prepareStatement(
@@ -212,7 +203,6 @@ public class Setter {
       prepstmt.execute();
       log.debug("Mobile Levels have been opened");
       result = true;
-      Database.closeConnection(conn);
 
     } catch (SQLException e) {
       log.error("Could not only open Mobile Levels: " + e.toString());
@@ -231,8 +221,7 @@ public class Setter {
   public static boolean openOnlyWebCategories(String ApplicationRoot, int unsafe) {
     log.debug("*** Setter.openOnlyWebCategories ***");
     boolean result = false;
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       PreparedStatement prepstmt =
           conn.prepareStatement(
@@ -251,7 +240,6 @@ public class Setter {
       prepstmt.execute();
       log.debug("Mobile Levels have been closed");
       result = true;
-      Database.closeConnection(conn);
 
     } catch (SQLException e) {
       log.error("Could not only open Web levels: " + e.toString());
@@ -271,8 +259,7 @@ public class Setter {
     log.debug("*** Setter.resetBadSubmission ***");
 
     boolean result = false;
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       log.debug("Prepairing resetUserBadSubmission call");
       PreparedStatement callstmnt = conn.prepareCall("CALL resetUserBadSubmission(?)");
@@ -280,7 +267,6 @@ public class Setter {
       log.debug("Executing resetUserBadSubmission statement on id '" + userId + "'");
       callstmnt.execute();
       result = true;
-      Database.closeConnection(conn);
 
     } catch (SQLException e) {
       log.error("resetUserBadSubmission Failure: " + e.toString());
@@ -344,8 +330,7 @@ public class Setter {
   public static String setCsrfChallengeFourCsrfToken(
       String userId, String csrfToken, String ApplicationRoot) {
     log.debug("*** setCsrfChallengeFourToken ***");
-    try {
-      Connection conn = Database.getChallengeConnection(ApplicationRoot, "csrfChallengeFour");
+    try (Connection conn = Database.getChallengeConnection(ApplicationRoot, "csrfChallengeFour")) {
 
       boolean tokenExists = false;
       log.debug("Preparing setSsrfChallengeFourToken call");
@@ -375,7 +360,6 @@ public class Setter {
       callstmnt.setString(2, userId);
       callstmnt.execute();
       callstmnt.close();
-      Database.closeConnection(conn);
 
     } catch (SQLException e) {
       log.error("CsrfChallenge4 TokenUpdate Failure: " + e.toString());
@@ -395,9 +379,8 @@ public class Setter {
       String userId, String csrfToken, String ApplicationRoot) {
     log.debug("*** setCsrfChallengeSevenToken ***");
     boolean result = false;
-    try {
-      Connection conn =
-          Database.getChallengeConnection(ApplicationRoot, "csrfChallengeEnumerateTokens");
+    try (Connection conn =
+        Database.getChallengeConnection(ApplicationRoot, "csrfChallengeEnumerateTokens")) {
 
       boolean updateToken = false;
       log.debug("Preparing setCsrfChallengeSevenToken call");
@@ -431,7 +414,6 @@ public class Setter {
       prestmnt.execute();
       result = true;
       prestmnt.close();
-      Database.closeConnection(conn);
 
     } catch (SQLException e) {
       log.error("csrfChallenge7EnumTokens TokenUpdate Failure: " + e.toString());
@@ -451,8 +433,7 @@ public class Setter {
       String ApplicationRoot, String moduleCategory, String openOrClosed) {
     log.debug("*** Setter.setModuleCategoryStatusOpen ***");
     boolean result = false;
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       PreparedStatement prepstmt =
           conn.prepareStatement("UPDATE modules SET moduleStatus = ? WHERE moduleCategory = ?");
@@ -461,7 +442,6 @@ public class Setter {
       prepstmt.execute();
       log.debug("Set " + moduleCategory + " to " + openOrClosed);
       result = true;
-      Database.closeConnection(conn);
 
     } catch (SQLException e) {
       log.error("Could not open/close category: " + e.toString());
@@ -481,8 +461,7 @@ public class Setter {
   public static boolean setModuleStatusClosed(String ApplicationRoot, String moduleId) {
     log.debug("*** Setter.setModuleStatusClosed ***");
     boolean result = false;
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       CallableStatement callstmt = conn.prepareCall("call moduleSetStatus(?, ?)");
       log.debug("Preparing moduleSetStatus procedure");
@@ -491,7 +470,6 @@ public class Setter {
       callstmt.execute();
       log.debug("Executed moduleSetStatus");
       result = true;
-      Database.closeConnection(conn);
 
     } catch (SQLException e) {
       log.error("Could not execute moduleSetStatus: " + e.toString());
@@ -511,8 +489,7 @@ public class Setter {
   public static boolean setModuleStatusOpen(String ApplicationRoot, String moduleId) {
     log.debug("*** Setter.setModuleStatusOpen ***");
     boolean result = false;
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       CallableStatement callstmt = conn.prepareCall("call moduleSetStatus(?, ?)");
       log.debug("Preparing moduleSetStatus procedure");
@@ -521,7 +498,6 @@ public class Setter {
       callstmt.execute();
       log.debug("Executed moduleSetStatus");
       result = true;
-      Database.closeConnection(conn);
 
     } catch (SQLException e) {
       log.error("Could not execute moduleSetStatus: " + e.toString());
@@ -544,8 +520,7 @@ public class Setter {
       String ApplicationRoot, String message, String userId, String moduleId) {
     log.debug("*** Setter.setStoredMessage ***");
     boolean result = false;
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       CallableStatement callstmt = conn.prepareCall("call resultMessageSet(?, ?, ?)");
       log.debug("Preparing resultMessageSet procedure");
@@ -555,7 +530,6 @@ public class Setter {
       callstmt.execute();
       log.debug("Executed resultMessageSet");
       result = true;
-      Database.closeConnection(conn);
 
     } catch (SQLException e) {
       log.error("Could not execute resultMessageSet: " + e.toString());
@@ -577,8 +551,7 @@ public class Setter {
     log.debug("*** Setter.suspendUser ***");
 
     boolean result = false;
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       log.debug("Prepairing suspendUser call");
       PreparedStatement callstmnt = conn.prepareCall("CALL suspendUser(?, ?)");
@@ -587,7 +560,6 @@ public class Setter {
       log.debug("Executing suspendUser statement on id '" + userId + "'");
       callstmnt.execute();
       result = true;
-      Database.closeConnection(conn);
 
     } catch (SQLException e) {
       log.error("suspendUser Failure: " + e.toString());
@@ -608,8 +580,7 @@ public class Setter {
     log.debug("*** Setter.unSuspendUser ***");
 
     boolean result = false;
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       log.debug("Prepairing suspendUser call");
       PreparedStatement callstmnt = conn.prepareCall("CALL unSuspendUser(?)");
@@ -617,7 +588,6 @@ public class Setter {
       log.debug("Executing unSuspendUser statement on id '" + userId + "'");
       callstmnt.execute();
       result = true;
-      Database.closeConnection(conn);
 
     } catch (SQLException e) {
       log.error("unSuspendUser Failure: " + e.toString());
@@ -638,8 +608,7 @@ public class Setter {
   public static boolean updateCsrfCounter(String ApplicationRoot, String moduleId, String userId) {
     log.debug("*** Getter.updateCsrfCounter ***");
     boolean result = false;
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       CallableStatement callstmt = conn.prepareCall("call resultMessagePlus(?, ?)");
       log.debug("Preparing resultMessagePlus procedure");
@@ -647,7 +616,6 @@ public class Setter {
       callstmt.setString(2, userId);
       callstmt.execute();
       result = true;
-      Database.closeConnection(conn);
 
     } catch (SQLException e) {
       log.error("Could not execute resultMessagePlus: " + e.toString());
@@ -669,14 +637,7 @@ public class Setter {
 
     boolean result = false;
 
-    Connection conn;
-    try {
-      conn = Database.getCoreConnection(ApplicationRoot);
-    } catch (SQLException e) {
-      log.debug("Could not get core connection: " + e.toString());
-      throw new RuntimeException(e);
-    }
-
+    // Phase 1: Verify current password (Getter.authUser manages its own connection)
     log.debug("Checking current password");
     String user[] = Getter.authUser(ApplicationRoot, userName, currentPassword);
 
@@ -685,36 +646,27 @@ public class Setter {
       log.debug("Current password incorrect!");
       return false;
     }
-    if (user != null && !user[0].isEmpty()) {
-      // Correct password, proceed
-      log.debug("Hashing password");
 
-      Argon2 argon2 = Argon2Factory.create();
+    // Phase 2: Hash new password (CPU-bound, ~100-200ms — do not hold a DB connection)
+    log.debug("Hashing password");
+    Argon2 argon2 = Argon2Factory.create();
+    String newHash = argon2.hash(10, 65536, 1, newPassword.toCharArray());
+    // TODO: wipe password from memory after hashing
 
-      String newHash = argon2.hash(10, 65536, 1, newPassword.toCharArray());
-      // TODO: wipe password from memory after hashing
-
-      log.debug("Preparing userPasswordChange call");
-      CallableStatement callstmnt;
-      try {
-        callstmnt = conn.prepareCall("call userPasswordChange(?, ?)");
-        callstmnt.setString(1, userName);
-
-        callstmnt.setString(2, newHash);
-        log.debug("Executing userPasswordChange");
-        callstmnt.execute();
-        result = true;
-      } catch (SQLException e) {
-        log.debug("Could not update password: " + e.toString());
-        throw new RuntimeException(e);
-      }
-
-    } else {
-      log.debug("Could not verify password!");
-      return false;
+    // Phase 3: Persist the new hash (short DB hold)
+    log.debug("Preparing userPasswordChange call");
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot);
+        CallableStatement callstmnt = conn.prepareCall("call userPasswordChange(?, ?)")) {
+      callstmnt.setString(1, userName);
+      callstmnt.setString(2, newHash);
+      log.debug("Executing userPasswordChange");
+      callstmnt.execute();
+      result = true;
+    } catch (SQLException e) {
+      log.debug("Could not update password: " + e.toString());
+      throw new RuntimeException(e);
     }
 
-    Database.closeConnection(conn);
     log.debug("*** END updatePassword ***");
     return result;
   }
@@ -733,11 +685,9 @@ public class Setter {
     boolean result = false;
 
     log.debug("Preparing username change call from username " + userName + " to " + newUsername);
-    PreparedStatement prestmnt;
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
-      prestmnt =
+      PreparedStatement prestmnt =
           conn.prepareStatement(
               "UPDATE users SET userName = ?, tempUsername = FALSE WHERE userName = ?;");
       prestmnt.setString(1, newUsername);
@@ -746,7 +696,6 @@ public class Setter {
       log.debug("Executing name change query");
       prestmnt.execute();
       result = true;
-      Database.closeConnection(conn);
 
     } catch (SQLException e) {
       log.debug("Could not update username: " + e.toString());
@@ -770,15 +719,13 @@ public class Setter {
     log.debug("*** Setter.updatePasswordAdmin ***");
 
     boolean result = false;
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
 
-      log.debug("Hashing password");
+    // Hash before opening a DB connection (Argon2 is CPU-bound, ~100-200ms)
+    log.debug("Hashing password");
+    Argon2 argon2 = Argon2Factory.create();
+    String newHash = argon2.hash(10, 65536, 1, newPassword.toCharArray());
 
-      Argon2 argon2 = Argon2Factory.create();
-
-      String newHash = argon2.hash(10, 65536, 1, newPassword.toCharArray());
-
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
       log.debug("Preparing userPasswordChangeAdmin call");
       CallableStatement callstmnt = conn.prepareCall("call userPasswordChangeAdmin(?, ?)");
       callstmnt.setString(1, userId);
@@ -786,7 +733,6 @@ public class Setter {
       log.debug("Executing userPasswordChangeAdmin");
       callstmnt.execute();
       result = true;
-      Database.closeConnection(conn);
 
     } catch (SQLException e) {
       log.error("updatePasswordAdmin Failure: " + e.toString());
@@ -807,8 +753,7 @@ public class Setter {
     log.debug("*** Setter.updatePlayerClass ***");
 
     String result = null;
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       log.debug("Preparing playerUpdateClass call");
       CallableStatement callstmnt = conn.prepareCall("call playerUpdateClass(?, ?)");
@@ -818,7 +763,6 @@ public class Setter {
       ResultSet resultSet = callstmnt.executeQuery();
       resultSet.next();
       result = resultSet.getString(1);
-      Database.closeConnection(conn);
 
     } catch (SQLException e) {
       log.error("playerUpdateClass Failure: " + e.toString());
@@ -839,8 +783,7 @@ public class Setter {
     log.debug("*** Setter.updatePlayerClassToNull ***");
 
     String result = null;
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       log.debug("Preparing playerUpdateClassToNull call");
       CallableStatement callstmnt = conn.prepareCall("call playerUpdateClassToNull(?)");
@@ -849,7 +792,6 @@ public class Setter {
       ResultSet resultSet = callstmnt.executeQuery();
       resultSet.next();
       result = resultSet.getString(1);
-      Database.closeConnection(conn);
 
     } catch (SQLException e) {
       log.error("updatePlayerClassToNull Failure: " + e.toString());
@@ -899,8 +841,7 @@ public class Setter {
 
     if (isRunning) {
 
-      try {
-        Connection conn = Database.getCoreConnection(ApplicationRoot);
+      try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
         log.debug("Preparing userUpdateResult call");
         CallableStatement callstmnt =
@@ -916,7 +857,6 @@ public class Setter {
         callstmnt.execute();
         // User Executed. Now Get the Level Name Langauge Key
         result = Getter.getModuleNameLocaleKey(ApplicationRoot, moduleId);
-        Database.closeConnection(conn);
 
       } catch (SQLException e) {
         log.error("userUpdateResult Failure: " + e.toString());
@@ -942,8 +882,7 @@ public class Setter {
     log.debug("*** Setter.updateUserPoints ***");
 
     boolean result = false;
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       log.debug("Preparing updateUserPoints call");
       PreparedStatement prestmnt =
@@ -953,7 +892,6 @@ public class Setter {
       log.debug("Executing updateUserPoints");
       prestmnt.execute();
       result = true;
-      Database.closeConnection(conn);
 
     } catch (SQLException e) {
       log.error("updateUserPoints Failure: " + e.toString());
@@ -974,8 +912,7 @@ public class Setter {
     log.debug("*** Setter.updateUserRole ***");
 
     String result = null;
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
       log.debug("Preparing userUpdateRole call");
       CallableStatement callstmnt = conn.prepareCall("call userUpdateRole(?, ?)");
@@ -985,7 +922,6 @@ public class Setter {
       ResultSet resultSet = callstmnt.executeQuery();
       resultSet.next();
       result = resultSet.getString(1);
-      Database.closeConnection(conn);
 
     } catch (SQLException e) {
       log.error("userUpdateRole Failure: " + e.toString());
@@ -1025,44 +961,43 @@ public class Setter {
     // We don't log passwords
     log.debug("userRole = " + userRole);
     log.debug("userAddress = " + userAddress);
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
 
+    // Hash before opening a DB connection (Argon2 is CPU-bound, ~100-200ms)
     log.debug("Hashing password");
-
     Argon2 argon2 = Argon2Factory.create();
-
     String hash = argon2.hash(10, 65536, 1, userPass.toCharArray());
     // TODO: wipe password from memory after hashing
 
-    log.debug("Executing userCreate procedure on Database");
-    CallableStatement callstmt = conn.prepareCall("call userCreate(?, ?, ?, ?, ?, ?, ?, ?, ?)");
-    callstmt.setString(1, classId);
-    callstmt.setString(2, userName);
-    callstmt.setString(3, hash);
-    callstmt.setString(4, userRole);
-    callstmt.setString(5, null); // ssoName
-    callstmt.setString(6, userAddress);
-    callstmt.setString(7, "login"); // login type
-    callstmt.setBoolean(8, tempPass);
-    callstmt.setBoolean(9, false); // Tempname
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+      log.debug("Executing userCreate procedure on Database");
+      CallableStatement callstmt = conn.prepareCall("call userCreate(?, ?, ?, ?, ?, ?, ?, ?, ?)");
+      callstmt.setString(1, classId);
+      callstmt.setString(2, userName);
+      callstmt.setString(3, hash);
+      callstmt.setString(4, userRole);
+      callstmt.setString(5, null); // ssoName
+      callstmt.setString(6, userAddress);
+      callstmt.setString(7, "login"); // login type
+      callstmt.setBoolean(8, tempPass);
+      callstmt.setBoolean(9, false); // Tempname
 
-    ResultSet registerAttempt = callstmt.executeQuery();
-    log.debug("Opening result set");
+      ResultSet registerAttempt = callstmt.executeQuery();
+      log.debug("Opening result set");
 
-    registerAttempt.next(); // Procedure Ran correctly
+      registerAttempt.next(); // Procedure Ran correctly
 
-    if (registerAttempt.getString(1) == null) {
-      // Registration success
-      log.debug("Register Success");
-      result = true;
-    } else {
-      // Registration failure
-      result = false;
-      log.debug("ResultSet contained -> " + registerAttempt.getString(1));
-      throw new SQLException(registerAttempt.getString(1));
+      if (registerAttempt.getString(1) == null) {
+        // Registration success
+        log.debug("Register Success");
+        result = true;
+      } else {
+        // Registration failure
+        result = false;
+        log.debug("ResultSet contained -> " + registerAttempt.getString(1));
+        throw new SQLException(registerAttempt.getString(1));
+      }
     }
 
-    Database.closeConnection(conn);
     log.debug("*** END userCreate ***");
 
     return result;
@@ -1079,94 +1014,95 @@ public class Setter {
     log.debug("ssoName = " + ssoName);
     // We don't log passwords
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
-
     String newUsername = userName;
 
-    try {
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
-      log.debug("Checking for duplicate usernames");
+      try {
 
-      boolean isDuplicate = true;
+        log.debug("Checking for duplicate usernames");
 
-      int duplicateCounter = 0;
+        boolean isDuplicate = true;
 
-      while (isDuplicate) {
+        int duplicateCounter = 0;
 
-        PreparedStatement prestmt =
-            conn.prepareStatement("SELECT ssoName FROM `users` WHERE userName = ?");
+        while (isDuplicate) {
 
-        prestmt.setString(1, newUsername);
+          PreparedStatement prestmt =
+              conn.prepareStatement("SELECT ssoName FROM `users` WHERE userName = ?");
 
-        ResultSet checkDuplicate = prestmt.executeQuery();
+          prestmt.setString(1, newUsername);
+
+          ResultSet checkDuplicate = prestmt.executeQuery();
+          log.debug("Opening result set");
+
+          if (checkDuplicate.next()) {
+            // Found a duplicate user, sigh
+            isDuplicate = true;
+            duplicateCounter++;
+
+            newUsername = userName + String.valueOf(duplicateCounter);
+
+            log.debug(
+                "Duplicate username found, changing to "
+                    + newUsername
+                    + " counter "
+                    + String.valueOf(duplicateCounter));
+
+          } else {
+            isDuplicate = false;
+          }
+
+          if (duplicateCounter > 500) {
+            String message =
+                "Bailing out of the de-duplicate loop at " + String.valueOf(duplicateCounter);
+            log.error(message);
+            throw new RuntimeException(message);
+          }
+        }
+
+      } catch (SQLException e) {
+        log.fatal("Failed to check for duplicate usernames: " + e.toString());
+        throw new SQLException(e);
+      }
+
+      try {
+
+        log.debug("Executing userCreate procedure on Database");
+
+        CallableStatement callstmt =
+            conn.prepareCall("call userCreate(?, ?, ?, ?, ?, ?, ?, ?, ?)");
+        callstmt.setString(1, classId);
+        callstmt.setString(2, newUsername);
+        callstmt.setString(3, "DISABLED");
+        callstmt.setString(4, userRole);
+        callstmt.setString(5, ssoName);
+        callstmt.setString(6, ""); // userAddress
+        callstmt.setString(7, "saml"); // login type
+        callstmt.setBoolean(8, false); // temppass
+        callstmt.setBoolean(9, true); // Tempname
+
+        ResultSet registerAttempt = callstmt.executeQuery();
         log.debug("Opening result set");
 
-        if (checkDuplicate.next()) {
-          // Found a duplicate user, sigh
-          isDuplicate = true;
-          duplicateCounter++;
+        registerAttempt.next(); // Procedure Ran correctly
 
-          newUsername = userName + String.valueOf(duplicateCounter);
-
-          log.debug(
-              "Duplicate username found, changing to "
-                  + newUsername
-                  + " counter "
-                  + String.valueOf(duplicateCounter));
-
+        if (registerAttempt.getString(1) == null) {
+          // Registration success
+          log.debug("Register Success");
+          result = newUsername;
         } else {
-          isDuplicate = false;
+          // Registration failure
+          result = null;
+          log.debug("ResultSet contained -> " + registerAttempt.getString(1));
+          throw new SQLException(registerAttempt.getString(1));
         }
 
-        if (duplicateCounter > 500) {
-          String message =
-              "Bailing out of the de-duplicate loop at " + String.valueOf(duplicateCounter);
-          log.error(message);
-          throw new RuntimeException(message);
-        }
+      } catch (SQLException e) {
+        log.fatal("userCreate Failure: " + e.toString());
+        throw new SQLException(e);
       }
-
-    } catch (SQLException e) {
-      log.fatal("Failed to check for duplicate usernames: " + e.toString());
-      throw new SQLException(e);
     }
-
-    try {
-
-      log.debug("Executing userCreate procedure on Database");
-
-      CallableStatement callstmt = conn.prepareCall("call userCreate(?, ?, ?, ?, ?, ?, ?, ?, ?)");
-      callstmt.setString(1, classId);
-      callstmt.setString(2, newUsername);
-      callstmt.setString(3, "DISABLED");
-      callstmt.setString(4, userRole);
-      callstmt.setString(5, ssoName);
-      callstmt.setString(6, ""); // userAddress
-      callstmt.setString(7, "saml"); // login type
-      callstmt.setBoolean(8, false); // temppass
-      callstmt.setBoolean(9, true); // Tempname
-
-      ResultSet registerAttempt = callstmt.executeQuery();
-      log.debug("Opening result set");
-
-      registerAttempt.next(); // Procedure Ran correctly
-
-      if (registerAttempt.getString(1) == null) {
-        // Registration success
-        log.debug("Register Success");
-        result = newUsername;
-      } else {
-        // Registration failure
-        result = null;
-        log.debug("ResultSet contained -> " + registerAttempt.getString(1));
-        throw new SQLException(registerAttempt.getString(1));
-      }
-
-    } catch (SQLException e) {
-      log.fatal("userCreate Failure: " + e.toString());
-      throw new SQLException(e);
-    }
-    Database.closeConnection(conn);
     log.debug("*** END userCreateSSO ***");
     return result;
   }
@@ -1176,8 +1112,7 @@ public class Setter {
     log.debug("*** Setter.userDelete ***");
     log.debug("userId = " + userId);
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
-    try {
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
       log.debug("Deleting User's Results");
       PreparedStatement callDelResults =
           conn.prepareStatement("DELETE FROM results WHERE userId = ?");
@@ -1196,7 +1131,6 @@ public class Setter {
       log.fatal("userDelete Failure: " + sqlEx.toString());
       throw new SQLException(sqlEx);
     }
-    Database.closeConnection(conn);
     log.debug("*** END userDelete ***");
     return result;
   }
@@ -1207,21 +1141,20 @@ public class Setter {
     log.debug("*** Setter.setAdminCheatStatus ***");
     log.debug("adminCheatsEnabled = " + adminCheatsEnabled);
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+      log.debug("Setting admin cheat setting");
+      PreparedStatement callAdminSetting =
+          conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
+      callAdminSetting.setBoolean(1, adminCheatsEnabled);
+      callAdminSetting.setString(2, "adminCheatsEnabled");
 
-    log.debug("Setting admin cheat setting");
-    PreparedStatement callAdminSetting =
-        conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
-    callAdminSetting.setBoolean(1, adminCheatsEnabled);
-    callAdminSetting.setString(2, "adminCheatsEnabled");
-
-    if (callAdminSetting.executeUpdate() == 1) {
-      result = true;
-    } else {
-      throw new RuntimeException("Could not set admin cheat setting");
+      if (callAdminSetting.executeUpdate() == 1) {
+        result = true;
+      } else {
+        throw new RuntimeException("Could not set admin cheat setting");
+      }
     }
 
-    Database.closeConnection(conn);
     log.debug("*** END setAdminCheatStatus ***");
     return result;
   }
@@ -1232,21 +1165,20 @@ public class Setter {
     log.debug("*** Setter.setPlayerCheatStatus ***");
     log.debug("playerCheatsEnabled = " + playerCheatsEnabled);
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+      log.debug("Setting player cheat setting");
+      PreparedStatement callPlayerSetting =
+          conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
+      callPlayerSetting.setBoolean(1, playerCheatsEnabled);
+      callPlayerSetting.setString(2, "playerCheatsEnabled");
 
-    log.debug("Setting player cheat setting");
-    PreparedStatement callPlayerSetting =
-        conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
-    callPlayerSetting.setBoolean(1, playerCheatsEnabled);
-    callPlayerSetting.setString(2, "playerCheatsEnabled");
-
-    if (callPlayerSetting.executeUpdate() == 1) {
-      result = true;
-    } else {
-      throw new RuntimeException("Could not set player cheat setting");
+      if (callPlayerSetting.executeUpdate() == 1) {
+        result = true;
+      } else {
+        throw new RuntimeException("Could not set player cheat setting");
+      }
     }
 
-    Database.closeConnection(conn);
     log.debug("*** END setPlayerCheatStatus ***");
     return result;
   }
@@ -1261,21 +1193,20 @@ public class Setter {
       throw new IllegalArgumentException("Invalid module layout: " + theModuleLayout);
     }
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+      log.debug("Setting player cheat setting");
+      PreparedStatement moduleLayoutSetting =
+          conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
+      moduleLayoutSetting.setString(1, theModuleLayout);
+      moduleLayoutSetting.setString(2, "modulelayout");
 
-    log.debug("Setting player cheat setting");
-    PreparedStatement moduleLayoutSetting =
-        conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
-    moduleLayoutSetting.setString(1, theModuleLayout);
-    moduleLayoutSetting.setString(2, "modulelayout");
-
-    if (moduleLayoutSetting.executeUpdate() == 1) {
-      result = true;
-    } else {
-      throw new RuntimeException("Could not set module layout to " + theModuleLayout);
+      if (moduleLayoutSetting.executeUpdate() == 1) {
+        result = true;
+      } else {
+        throw new RuntimeException("Could not set module layout to " + theModuleLayout);
+      }
     }
 
-    Database.closeConnection(conn);
     log.debug("*** END setModulelayout ***");
     return result;
   }
@@ -1286,23 +1217,22 @@ public class Setter {
     log.debug("*** Setter.setFeedbackStatus ***");
     log.debug("feedbackStatus = " + theFeebackStatus);
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+      log.debug("Setting feedback status setting");
+      PreparedStatement getFeedbackSetting =
+          conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
+      getFeedbackSetting.setBoolean(1, theFeebackStatus);
+      getFeedbackSetting.setString(2, "enableFeedback");
 
-    log.debug("Setting feedback status setting");
-    PreparedStatement getFeedbackSetting =
-        conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
-    getFeedbackSetting.setBoolean(1, theFeebackStatus);
-    getFeedbackSetting.setString(2, "enableFeedback");
+      int updateResult = getFeedbackSetting.executeUpdate();
 
-    int updateResult = getFeedbackSetting.executeUpdate();
-
-    if (updateResult == 1) {
-      result = true;
-    } else {
-      throw new RuntimeException("Could not set feedback status to " + theFeebackStatus);
+      if (updateResult == 1) {
+        result = true;
+      } else {
+        throw new RuntimeException("Could not set feedback status to " + theFeebackStatus);
+      }
     }
 
-    Database.closeConnection(conn);
     log.debug("*** END setFeedbackStatus ***");
     return result;
   }
@@ -1313,21 +1243,21 @@ public class Setter {
     log.debug("*** Setter.setRegistrationStatus ***");
     log.debug("enableRegistration = " + theRegistrationStatus);
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+      log.debug("Setting registration status setting");
+      PreparedStatement setRegistrationSetting =
+          conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
+      setRegistrationSetting.setBoolean(1, theRegistrationStatus);
+      setRegistrationSetting.setString(2, "openRegistration");
 
-    log.debug("Setting registration status setting");
-    PreparedStatement setRegistrationSetting =
-        conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
-    setRegistrationSetting.setBoolean(1, theRegistrationStatus);
-    setRegistrationSetting.setString(2, "openRegistration");
-
-    if (setRegistrationSetting.executeUpdate() == 1) {
-      result = true;
-    } else {
-      throw new RuntimeException("Could not set registration status to " + theRegistrationStatus);
+      if (setRegistrationSetting.executeUpdate() == 1) {
+        result = true;
+      } else {
+        throw new RuntimeException(
+            "Could not set registration status to " + theRegistrationStatus);
+      }
     }
 
-    Database.closeConnection(conn);
     log.debug("*** END setRegistrationStatus ***");
     return result;
   }
@@ -1346,21 +1276,20 @@ public class Setter {
       throw new IllegalArgumentException("Invalid scoreboard status: " + theScoreboardStatus);
     }
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+      log.debug("Setting scoreboard status setting");
+      PreparedStatement scoreboardSetting =
+          conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
+      scoreboardSetting.setString(1, theScoreboardStatus);
+      scoreboardSetting.setString(2, "scoreboardStatus");
 
-    log.debug("Setting scoreboard status setting");
-    PreparedStatement scoreboardSetting =
-        conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
-    scoreboardSetting.setString(1, theScoreboardStatus);
-    scoreboardSetting.setString(2, "scoreboardStatus");
-
-    if (scoreboardSetting.executeUpdate() == 1) {
-      result = true;
-    } else {
-      throw new RuntimeException("Could not set scoreboard status to " + theScoreboardStatus);
+      if (scoreboardSetting.executeUpdate() == 1) {
+        result = true;
+      } else {
+        throw new RuntimeException("Could not set scoreboard status to " + theScoreboardStatus);
+      }
     }
 
-    Database.closeConnection(conn);
     log.debug("*** END setScoreboardStatus ***");
     return result;
   }
@@ -1371,21 +1300,20 @@ public class Setter {
     log.debug("*** Setter.setScoreboardClass ***");
     log.debug("scoreboardClass = " + theScoreboardClass);
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+      log.debug("Setting scoreboard class setting");
+      PreparedStatement scoreboardClassSetting =
+          conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
+      scoreboardClassSetting.setString(1, theScoreboardClass);
+      scoreboardClassSetting.setString(2, "scoreboardClass");
 
-    log.debug("Setting scoreboard class setting");
-    PreparedStatement scoreboardClassSetting =
-        conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
-    scoreboardClassSetting.setString(1, theScoreboardClass);
-    scoreboardClassSetting.setString(2, "scoreboardClass");
-
-    if (scoreboardClassSetting.executeUpdate() == 1) {
-      result = true;
-    } else {
-      throw new RuntimeException("Could not set scoreboard class to " + theScoreboardClass);
+      if (scoreboardClassSetting.executeUpdate() == 1) {
+        result = true;
+      } else {
+        throw new RuntimeException("Could not set scoreboard class to " + theScoreboardClass);
+      }
     }
 
-    Database.closeConnection(conn);
     log.debug("*** END setScoreboardClass ***");
     return result;
   }
@@ -1396,21 +1324,20 @@ public class Setter {
     log.debug("*** Setter.setStartTimeStatus ***");
     log.debug("theLockTimeStatus = " + theStartTimeStatus);
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+      log.debug("Setting start time setting");
+      PreparedStatement lockTimeStatement =
+          conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
+      lockTimeStatement.setBoolean(1, theStartTimeStatus);
+      lockTimeStatement.setString(2, "hasStartTime");
 
-    log.debug("Setting start time setting");
-    PreparedStatement lockTimeStatement =
-        conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
-    lockTimeStatement.setBoolean(1, theStartTimeStatus);
-    lockTimeStatement.setString(2, "hasStartTime");
-
-    if (lockTimeStatement.executeUpdate() == 1) {
-      result = true;
-    } else {
-      throw new RuntimeException("Could not set start time status to " + theStartTimeStatus);
+      if (lockTimeStatement.executeUpdate() == 1) {
+        result = true;
+      } else {
+        throw new RuntimeException("Could not set start time status to " + theStartTimeStatus);
+      }
     }
 
-    Database.closeConnection(conn);
     log.debug("*** END setStartTimeStatus ***");
     return result;
   }
@@ -1421,21 +1348,20 @@ public class Setter {
     log.debug("*** Setter.setStartTime ***");
     log.debug("theLockTime = " + theStartTime);
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+      log.debug("Setting start time");
+      PreparedStatement lockTimeStatement =
+          conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
+      lockTimeStatement.setString(1, theStartTime.toString());
+      lockTimeStatement.setString(2, "startTime");
 
-    log.debug("Setting start time");
-    PreparedStatement lockTimeStatement =
-        conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
-    lockTimeStatement.setString(1, theStartTime.toString());
-    lockTimeStatement.setString(2, "startTime");
-
-    if (lockTimeStatement.executeUpdate() == 1) {
-      result = true;
-    } else {
-      throw new RuntimeException("Could not set start time to " + theStartTime);
+      if (lockTimeStatement.executeUpdate() == 1) {
+        result = true;
+      } else {
+        throw new RuntimeException("Could not set start time to " + theStartTime);
+      }
     }
 
-    Database.closeConnection(conn);
     log.debug("*** END setStartTime ***");
     return result;
   }
@@ -1446,21 +1372,20 @@ public class Setter {
     log.debug("*** Setter.setLockTimeStatus ***");
     log.debug("theLockTimeStatus = " + theLockTimeStatus);
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+      log.debug("Setting lock timestamp setting");
+      PreparedStatement lockTimeStatement =
+          conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
+      lockTimeStatement.setBoolean(1, theLockTimeStatus);
+      lockTimeStatement.setString(2, "hasLockTime");
 
-    log.debug("Setting lock timestamp setting");
-    PreparedStatement lockTimeStatement =
-        conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
-    lockTimeStatement.setBoolean(1, theLockTimeStatus);
-    lockTimeStatement.setString(2, "hasLockTime");
-
-    if (lockTimeStatement.executeUpdate() == 1) {
-      result = true;
-    } else {
-      throw new RuntimeException("Could not set lock time status to " + theLockTimeStatus);
+      if (lockTimeStatement.executeUpdate() == 1) {
+        result = true;
+      } else {
+        throw new RuntimeException("Could not set lock time status to " + theLockTimeStatus);
+      }
     }
 
-    Database.closeConnection(conn);
     log.debug("*** END setLockTimeStatus ***");
     return result;
   }
@@ -1471,21 +1396,20 @@ public class Setter {
     log.debug("*** Setter.setLockTime ***");
     log.debug("theLockTime = " + theLockTime);
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+      log.debug("Setting lock time");
+      PreparedStatement lockTimeStatement =
+          conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
+      lockTimeStatement.setString(1, theLockTime.toString());
+      lockTimeStatement.setString(2, "lockTime");
 
-    log.debug("Setting lock time");
-    PreparedStatement lockTimeStatement =
-        conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
-    lockTimeStatement.setString(1, theLockTime.toString());
-    lockTimeStatement.setString(2, "lockTime");
-
-    if (lockTimeStatement.executeUpdate() == 1) {
-      result = true;
-    } else {
-      throw new RuntimeException("Could not set lock time to " + theLockTime);
+      if (lockTimeStatement.executeUpdate() == 1) {
+        result = true;
+      } else {
+        throw new RuntimeException("Could not set lock time to " + theLockTime);
+      }
     }
 
-    Database.closeConnection(conn);
     log.debug("*** END setLockTime ***");
     return result;
   }
@@ -1496,21 +1420,20 @@ public class Setter {
     log.debug("*** Setter.setEndTimeStatus ***");
     log.debug("theEndTimeStatus = " + theEndTimeStatus);
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+      log.debug("Setting end time setting");
+      PreparedStatement lockTimeStatement =
+          conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
+      lockTimeStatement.setBoolean(1, theEndTimeStatus);
+      lockTimeStatement.setString(2, "hasEndTime");
 
-    log.debug("Setting end time setting");
-    PreparedStatement lockTimeStatement =
-        conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
-    lockTimeStatement.setBoolean(1, theEndTimeStatus);
-    lockTimeStatement.setString(2, "hasEndTime");
-
-    if (lockTimeStatement.executeUpdate() == 1) {
-      result = true;
-    } else {
-      throw new RuntimeException("Could not set end time status to " + theEndTimeStatus);
+      if (lockTimeStatement.executeUpdate() == 1) {
+        result = true;
+      } else {
+        throw new RuntimeException("Could not set end time status to " + theEndTimeStatus);
+      }
     }
 
-    Database.closeConnection(conn);
     log.debug("*** END theEndTimeStatus ***");
     return result;
   }
@@ -1521,21 +1444,20 @@ public class Setter {
     log.debug("*** Setter.setEndTime ***");
     log.debug("theLockTime = " + theEndTime);
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+      log.debug("Setting end time");
+      PreparedStatement endTimeStatement =
+          conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
+      endTimeStatement.setString(1, theEndTime.toString());
+      endTimeStatement.setString(2, "endTime");
 
-    log.debug("Setting end time");
-    PreparedStatement endTimeStatement =
-        conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
-    endTimeStatement.setString(1, theEndTime.toString());
-    endTimeStatement.setString(2, "endTime");
-
-    if (endTimeStatement.executeUpdate() == 1) {
-      result = true;
-    } else {
-      throw new RuntimeException("Could not set end time to " + theEndTime);
+      if (endTimeStatement.executeUpdate() == 1) {
+        result = true;
+      } else {
+        throw new RuntimeException("Could not set end time to " + theEndTime);
+      }
     }
 
-    Database.closeConnection(conn);
     log.debug("*** END setEndTime ***");
     return result;
   }
@@ -1546,21 +1468,20 @@ public class Setter {
     log.debug("*** Setter.setDefaultClass ***");
     log.debug("theLockTime = " + theDefaultClass);
 
-    Connection conn = Database.getCoreConnection(ApplicationRoot);
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+      log.debug("Setting default class");
+      PreparedStatement endTimeStatement =
+          conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
+      endTimeStatement.setString(1, theDefaultClass);
+      endTimeStatement.setString(2, "defaultClass");
 
-    log.debug("Setting default class");
-    PreparedStatement endTimeStatement =
-        conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
-    endTimeStatement.setString(1, theDefaultClass);
-    endTimeStatement.setString(2, "defaultClass");
-
-    if (endTimeStatement.executeUpdate() == 1) {
-      result = true;
-    } else {
-      throw new RuntimeException("Could not set default class to " + theDefaultClass);
+      if (endTimeStatement.executeUpdate() == 1) {
+        result = true;
+      } else {
+        throw new RuntimeException("Could not set default class to " + theDefaultClass);
+      }
     }
 
-    Database.closeConnection(conn);
     log.debug("*** END setDefaultClass ***");
     return result;
   }

--- a/src/main/java/dbProcs/Setter.java
+++ b/src/main/java/dbProcs/Setter.java
@@ -629,7 +629,7 @@ public class Setter {
    * @param userName User name of the user
    * @param currentPassword User's current password
    * @param newPassword New password to use in update
-   * @return ResultSet that contains error details if not successful
+   * @return true if the password was updated, false if the current password did not verify
    */
   public static boolean updatePassword(
       String ApplicationRoot, String userName, String currentPassword, String newPassword) {
@@ -673,10 +673,9 @@ public class Setter {
 
   /**
    * @param ApplicationRoot The current running context of the application
-   * @param userName User name of the user
-   * @param currentPassword User's current password
-   * @param newPassword New password to use in update
-   * @return ResultSet that contains error details if not successful
+   * @param userName Existing user name to rename
+   * @param newUsername The new user name to assign
+   * @return true if the username was updated successfully
    */
   public static boolean updateUsername(
       String ApplicationRoot, String userName, String newUsername) {
@@ -840,11 +839,12 @@ public class Setter {
 
     if (isRunning) {
 
-      try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+      boolean updated = false;
+      try (Connection conn = Database.getCoreConnection(ApplicationRoot);
+          CallableStatement callstmnt =
+              conn.prepareCall("call userUpdateResult(?, ?, ?, ?, ?, ?, ?)")) {
 
         log.debug("Preparing userUpdateResult call");
-        CallableStatement callstmnt =
-            conn.prepareCall("call userUpdateResult(?, ?, ?, ?, ?, ?, ?)");
         callstmnt.setString(1, moduleId);
         callstmnt.setString(2, userId);
         callstmnt.setInt(3, before);
@@ -854,12 +854,16 @@ public class Setter {
         callstmnt.setString(7, extra);
         log.debug("Executing userUpdateResult");
         callstmnt.execute();
-        // User Executed. Now Get the Level Name Langauge Key
-        result = Getter.getModuleNameLocaleKey(ApplicationRoot, moduleId);
+        updated = true;
 
       } catch (SQLException e) {
         log.error("userUpdateResult Failure: " + e.toString());
-        result = null;
+      }
+
+      // Release the core connection before calling back into Getter, which opens its own.
+      // Holding two pooled connections per call doubles pool pressure under concurrency.
+      if (updated) {
+        result = Getter.getModuleNameLocaleKey(ApplicationRoot, moduleId);
       }
     } else {
       log.error("Error: Can't allow results to be stored when CTF isn't running");

--- a/src/main/java/dbProcs/Setter.java
+++ b/src/main/java/dbProcs/Setter.java
@@ -1070,8 +1070,7 @@ public class Setter {
 
         log.debug("Executing userCreate procedure on Database");
 
-        CallableStatement callstmt =
-            conn.prepareCall("call userCreate(?, ?, ?, ?, ?, ?, ?, ?, ?)");
+        CallableStatement callstmt = conn.prepareCall("call userCreate(?, ?, ?, ?, ?, ?, ?, ?, ?)");
         callstmt.setString(1, classId);
         callstmt.setString(2, newUsername);
         callstmt.setString(3, "DISABLED");
@@ -1253,8 +1252,7 @@ public class Setter {
       if (setRegistrationSetting.executeUpdate() == 1) {
         result = true;
       } else {
-        throw new RuntimeException(
-            "Could not set registration status to " + theRegistrationStatus);
+        throw new RuntimeException("Could not set registration status to " + theRegistrationStatus);
       }
     }
 

--- a/src/main/java/dbProcs/Setter.java
+++ b/src/main/java/dbProcs/Setter.java
@@ -606,7 +606,7 @@ public class Setter {
    * @return Boolean reflecting the success of the operation
    */
   public static boolean updateCsrfCounter(String ApplicationRoot, String moduleId, String userId) {
-    log.debug("*** Getter.updateCsrfCounter ***");
+    log.debug("*** Setter.updateCsrfCounter ***");
     boolean result = false;
     try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
 
@@ -1028,29 +1028,31 @@ public class Setter {
 
         while (isDuplicate) {
 
-          PreparedStatement prestmt =
-              conn.prepareStatement("SELECT ssoName FROM `users` WHERE userName = ?");
+          try (PreparedStatement prestmt =
+              conn.prepareStatement("SELECT ssoName FROM `users` WHERE userName = ?")) {
 
-          prestmt.setString(1, newUsername);
+            prestmt.setString(1, newUsername);
 
-          ResultSet checkDuplicate = prestmt.executeQuery();
-          log.debug("Opening result set");
+            try (ResultSet checkDuplicate = prestmt.executeQuery()) {
+              log.debug("Opening result set");
 
-          if (checkDuplicate.next()) {
-            // Found a duplicate user, sigh
-            isDuplicate = true;
-            duplicateCounter++;
+              if (checkDuplicate.next()) {
+                // Found a duplicate user, sigh
+                isDuplicate = true;
+                duplicateCounter++;
 
-            newUsername = userName + String.valueOf(duplicateCounter);
+                newUsername = userName + String.valueOf(duplicateCounter);
 
-            log.debug(
-                "Duplicate username found, changing to "
-                    + newUsername
-                    + " counter "
-                    + String.valueOf(duplicateCounter));
+                log.debug(
+                    "Duplicate username found, changing to "
+                        + newUsername
+                        + " counter "
+                        + String.valueOf(duplicateCounter));
 
-          } else {
-            isDuplicate = false;
+              } else {
+                isDuplicate = false;
+              }
+            }
           }
 
           if (duplicateCounter > 500) {
@@ -1066,11 +1068,10 @@ public class Setter {
         throw new SQLException(e);
       }
 
-      try {
+      log.debug("Executing userCreate procedure on Database");
 
-        log.debug("Executing userCreate procedure on Database");
-
-        CallableStatement callstmt = conn.prepareCall("call userCreate(?, ?, ?, ?, ?, ?, ?, ?, ?)");
+      try (CallableStatement callstmt =
+          conn.prepareCall("call userCreate(?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
         callstmt.setString(1, classId);
         callstmt.setString(2, newUsername);
         callstmt.setString(3, "DISABLED");
@@ -1081,20 +1082,21 @@ public class Setter {
         callstmt.setBoolean(8, false); // temppass
         callstmt.setBoolean(9, true); // Tempname
 
-        ResultSet registerAttempt = callstmt.executeQuery();
-        log.debug("Opening result set");
+        try (ResultSet registerAttempt = callstmt.executeQuery()) {
+          log.debug("Opening result set");
 
-        registerAttempt.next(); // Procedure Ran correctly
+          registerAttempt.next(); // Procedure Ran correctly
 
-        if (registerAttempt.getString(1) == null) {
-          // Registration success
-          log.debug("Register Success");
-          result = newUsername;
-        } else {
-          // Registration failure
-          result = null;
-          log.debug("ResultSet contained -> " + registerAttempt.getString(1));
-          throw new SQLException(registerAttempt.getString(1));
+          if (registerAttempt.getString(1) == null) {
+            // Registration success
+            log.debug("Register Success");
+            result = newUsername;
+          } else {
+            // Registration failure
+            result = null;
+            log.debug("ResultSet contained -> " + registerAttempt.getString(1));
+            throw new SQLException(registerAttempt.getString(1));
+          }
         }
 
       } catch (SQLException e) {

--- a/src/main/java/dbProcs/Setter.java
+++ b/src/main/java/dbProcs/Setter.java
@@ -685,11 +685,10 @@ public class Setter {
     boolean result = false;
 
     log.debug("Preparing username change call from username " + userName + " to " + newUsername);
-    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
-
-      PreparedStatement prestmnt =
-          conn.prepareStatement(
-              "UPDATE users SET userName = ?, tempUsername = FALSE WHERE userName = ?;");
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot);
+        PreparedStatement prestmnt =
+            conn.prepareStatement(
+                "UPDATE users SET userName = ?, tempUsername = FALSE WHERE userName = ?;")) {
       prestmnt.setString(1, newUsername);
 
       prestmnt.setString(2, userName);
@@ -725,9 +724,9 @@ public class Setter {
     Argon2 argon2 = Argon2Factory.create();
     String newHash = argon2.hash(10, 65536, 1, newPassword.toCharArray());
 
-    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot);
+        CallableStatement callstmnt = conn.prepareCall("call userPasswordChangeAdmin(?, ?)")) {
       log.debug("Preparing userPasswordChangeAdmin call");
-      CallableStatement callstmnt = conn.prepareCall("call userPasswordChangeAdmin(?, ?)");
       callstmnt.setString(1, userId);
       callstmnt.setString(2, newHash);
       log.debug("Executing userPasswordChangeAdmin");
@@ -968,9 +967,10 @@ public class Setter {
     String hash = argon2.hash(10, 65536, 1, userPass.toCharArray());
     // TODO: wipe password from memory after hashing
 
-    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot);
+        CallableStatement callstmt =
+            conn.prepareCall("call userCreate(?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
       log.debug("Executing userCreate procedure on Database");
-      CallableStatement callstmt = conn.prepareCall("call userCreate(?, ?, ?, ?, ?, ?, ?, ?, ?)");
       callstmt.setString(1, classId);
       callstmt.setString(2, userName);
       callstmt.setString(3, hash);
@@ -981,20 +981,21 @@ public class Setter {
       callstmt.setBoolean(8, tempPass);
       callstmt.setBoolean(9, false); // Tempname
 
-      ResultSet registerAttempt = callstmt.executeQuery();
-      log.debug("Opening result set");
+      try (ResultSet registerAttempt = callstmt.executeQuery()) {
+        log.debug("Opening result set");
 
-      registerAttempt.next(); // Procedure Ran correctly
+        registerAttempt.next(); // Procedure Ran correctly
 
-      if (registerAttempt.getString(1) == null) {
-        // Registration success
-        log.debug("Register Success");
-        result = true;
-      } else {
-        // Registration failure
-        result = false;
-        log.debug("ResultSet contained -> " + registerAttempt.getString(1));
-        throw new SQLException(registerAttempt.getString(1));
+        if (registerAttempt.getString(1) == null) {
+          // Registration success
+          log.debug("Register Success");
+          result = true;
+        } else {
+          // Registration failure
+          result = false;
+          log.debug("ResultSet contained -> " + registerAttempt.getString(1));
+          throw new SQLException(registerAttempt.getString(1));
+        }
       }
     }
 
@@ -1190,7 +1191,9 @@ public class Setter {
     log.debug("*** Setter.setModulelayout ***");
     log.debug("playerCheatsEnabled = " + theModuleLayout);
 
-    if (theModuleLayout != "ctf" && theModuleLayout != "tournament" && theModuleLayout != "open") {
+    if (!"ctf".equals(theModuleLayout)
+        && !"tournament".equals(theModuleLayout)
+        && !"open".equals(theModuleLayout)) {
       throw new IllegalArgumentException("Invalid module layout: " + theModuleLayout);
     }
 
@@ -1268,11 +1271,11 @@ public class Setter {
     log.debug("*** Setter.setScoreboardStatus ***");
     log.debug("scoreboardStatus = " + theScoreboardStatus);
 
-    if (theScoreboardStatus != "closed"
-        && theScoreboardStatus != "adminOnly"
-        && theScoreboardStatus != "classSpecific"
-        && theScoreboardStatus != "open"
-        && theScoreboardStatus != "public") {
+    if (!"closed".equals(theScoreboardStatus)
+        && !"adminOnly".equals(theScoreboardStatus)
+        && !"classSpecific".equals(theScoreboardStatus)
+        && !"open".equals(theScoreboardStatus)
+        && !"public".equals(theScoreboardStatus)) {
       throw new IllegalArgumentException("Invalid scoreboard status: " + theScoreboardStatus);
     }
 

--- a/src/main/java/servlets/Setup.java
+++ b/src/main/java/servlets/Setup.java
@@ -19,6 +19,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.sql.Connection;
+import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Locale;
@@ -204,14 +205,26 @@ public class Setup extends HttpServlet {
         log.error("Authorization mismatch: " + auth + " does not equal " + dbAuth);
 
       } else {
-        // Test the user's entered database properties
+        // Test the user's entered database properties. Use DriverManager directly instead of
+        // the pool: setup is a one-shot credential check that runs before database.properties
+        // exists, and routing it through a pooled DataSource keyed on (url, user) would
+        // silently reuse a stale pool when the password changes between setup attempts.
+        //
+        // Append connectTimeout=5000 so a typo'd host or unreachable port fails fast (matching
+        // ConnectionPool's 5s default) instead of hanging on the OS's default TCP connect
+        // timeout — DriverManager has no built-in timeout and the setup page would otherwise
+        // appear to freeze.
         Boolean connectionSuccess = false;
         log.debug("Attempting to connect to database");
 
-        try {
-          Connection conn =
-              Database.getConnection(driverType, connectionURL, dbOptions, dbUser, dbPass);
-          Database.closeConnection(conn);
+        String testJdbcUrl;
+        if (dbOptions != null && !dbOptions.isEmpty()) {
+          testJdbcUrl = connectionURL + "?" + dbOptions + "&connectTimeout=5000";
+        } else {
+          testJdbcUrl = connectionURL + "?connectTimeout=5000";
+        }
+
+        try (Connection conn = DriverManager.getConnection(testJdbcUrl, dbUser, dbPass)) {
           connectionSuccess = true;
           log.debug("Database connection successful");
 
@@ -463,17 +476,21 @@ public class Setup extends HttpServlet {
     String data = FileUtils.readFileToString(file, Charset.defaultCharset());
 
     log.debug("Initializing core database");
-    Connection databaseConnection = Database.getDatabaseConnection(null, true);
-    Statement psProcToexecute = databaseConnection.createStatement();
-    psProcToexecute.executeUpdate(data);
+    try (Connection databaseConnection = Database.getDatabaseConnection(null, true)) {
+      try (Statement psProcToexecute = databaseConnection.createStatement()) {
+        psProcToexecute.executeUpdate(data);
+      }
 
-    file =
-        new File(getClass().getClassLoader().getResource("/database/moduleSchemas.sql").getFile());
-    data = FileUtils.readFileToString(file, Charset.defaultCharset());
-    log.debug("Initializing module database");
+      file =
+          new File(
+              getClass().getClassLoader().getResource("/database/moduleSchemas.sql").getFile());
+      data = FileUtils.readFileToString(file, Charset.defaultCharset());
+      log.debug("Initializing module database");
 
-    psProcToexecute = databaseConnection.createStatement();
-    psProcToexecute.executeUpdate(data);
+      try (Statement psProcToexecute = databaseConnection.createStatement()) {
+        psProcToexecute.executeUpdate(data);
+      }
+    }
   }
 
   private synchronized void executeMongoScript() throws IOException {
@@ -502,9 +519,10 @@ public class Setup extends HttpServlet {
 
     data = FileUtils.readFileToString(file, Charset.defaultCharset());
 
-    Connection databaseConnection = Database.getDatabaseConnection(null, true);
-    Statement psProcToexecute = databaseConnection.createStatement();
-    psProcToexecute.executeUpdate(data);
+    try (Connection databaseConnection = Database.getDatabaseConnection(null, true);
+        Statement psProcToexecute = databaseConnection.createStatement()) {
+      psProcToexecute.executeUpdate(data);
+    }
   }
 
   private synchronized void openUnsafeLevels() {


### PR DESCRIPTION
> **Stacked on [#816](https://github.com/OWASP/SecurityShepherd/pull/816).** Merge after #816, just like [#817](https://github.com/OWASP/SecurityShepherd/pull/817) was. The diff against `dev` will include #816 + #817 until #816 lands.

## Summary

Setter.java's counterpart to [#817](https://github.com/OWASP/SecurityShepherd/pull/817). Pre-pooling each request opened a fresh DB connection, so leaks were invisible (the original symptom of #536 was MySQL slowly bleeding out until Tomcat was manually restarted). With HikariCP capping the core pool at 20 and timing out at 5s (#816 / #819), every leaky path now surfaces fast as `SQLTransientConnectionException: CorePool - Connection is not available, request timed out after 5005ms.`

This PR closes the Setter side of those leaks.

## Changes

| Area | Change |
|------|--------|
| `Setter.java` (~41 call sites) | All `Database.getCoreConnection` / `getChallengeConnection` borrows converted to try-with-resources. All manual `Database.closeConnection` calls removed. `Connection` is `AutoCloseable` — returns to the pool on every code path including thrown exceptions. |
| `updatePassword`, `updatePasswordAdmin`, `userCreate` | Apply the auth-hold-time fix from [#819](https://github.com/OWASP/SecurityShepherd/pull/819) to Setter: move Argon2 hash (CPU-bound, ~100-200ms) **before** connection acquisition. Frees pool capacity for concurrent callers. |
| `updatePassword` | Additionally restructured: phase 1 (verify) uses `Getter.authUser`'s own connection scope; phase 2 (hash) holds none; phase 3 (UPDATE) opens a fresh connection. Previously held one connection across all three phases *and* called `Getter.authUser` (which opens its own) inside the outer scope. |
| 17 settings methods (`setAdminCheatStatus`, `setFeedbackStatus`, `setLockTime`, etc.) | These declared `Connection` outside any `try` and threw `RuntimeException` before manual `closeConnection`, leaking unconditionally on every settings-update failure. Now bounded by try-with-resources. |
| `SetterCorePoolLeakIT.java` (new) | Mirrors `GetterCorePoolLeakIT` — hammers `resetBadSubmission` and `suspendUser` 500x each with synthetic userIds and asserts `ConnectionPool.getCoreActiveConnections` stays bounded. |

The first commit is a small drive-by fix for three pre-existing IT files (`GetterCorePoolLeakIT`, `GetterAuthIT`, `SetupIT`) that the dev->dev#536 merge missed when migrating off `TestProperties.executeSql(Logger)` (the API was split in [#832](https://github.com/OWASP/SecurityShepherd/pull/832)). Without it the branch doesn't compile. One-line swap to `ensureSchemaReady(log) + reseedTestData()` to match the pattern used in the 35 other ITs.

## Verification

- `mvn test-compile` clean.
- `SetterCorePoolLeakIT` and `GetterCorePoolLeakIT` both pass — 500 × 2 iterations leave `coreActiveConnections == 0`.
- `SetterIT#testUpdatePassword`, `testUpdatePasswordAdmin`, `testUpdateUsername`, `testUpdateUserRole` pass — covers the substantively refactored methods.
- `SetterIT#testSuspendUser` fails on this branch, but it was already failing on stock `origin/dev#536` before this PR — pre-existing failure, not a regression.

## Scope

This PR is `Setter.java` only — matching #817's narrow scope. The follow-up work (servlets, `Setup`, scoreboard exporters, SAML / SSO paths, challenge servlets) needs the same try-with-resources treatment file by file. Discussion welcome on whether to bundle that as one PR or split per package on this branch — it's the same mechanical transform either way.

## Test plan

- [ ] CI integration-tests job passes (or — if it inherits dev#536's pre-existing breakage — passes the new `SetterCorePoolLeakIT` and the update-family tests in `SetterIT`)
- [ ] Manual: hit a Setter-heavy admin path (e.g. open/close modules, suspend a user, change scoreboard settings) under load and verify pool active connections stay bounded