### PR TITLE
test: tighten GetterCorePoolLeakIT leak assertion (stacked on #834)

### DIFF
--- a/src/it/java/dbProcs/GetterCorePoolLeakIT.java
+++ b/src/it/java/dbProcs/GetterCorePoolLeakIT.java
@@ -1,5 +1,6 @@
 package dbProcs;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -21,9 +22,6 @@ public class GetterCorePoolLeakIT {
   private static final Logger log = LogManager.getLogger(GetterCorePoolLeakIT.class);
   private static boolean databaseAvailable = false;
   private static final String applicationRoot = "";
-
-  /** Must stay within configured core pool max (see database.properties / ConnectionPool). */
-  private static final int MAX_ALLOWED_ACTIVE = 32;
 
   @BeforeAll
   public static void setup() throws IOException, SQLException {
@@ -50,6 +48,12 @@ public class GetterCorePoolLeakIT {
     assumeTrue(databaseAvailable, "Database not available");
   }
 
+  /**
+   * The loop is serial, so a non-leaking pool must return active count to the pre-call baseline
+   * after every iteration. Asserting equality with baseline (typically 0) detects leaks
+   * deterministically — a hardcoded ceiling can still pass while the pool saturates (e.g. with
+   * coreMax=20 and Hikari's 5s acquire timeout, callers throw long before active reaches 32).
+   */
   @Test
   public void repeatedAuthUserDoesNotExhaustCorePool() {
     requireDatabase();
@@ -65,8 +69,13 @@ public class GetterCorePoolLeakIT {
         "GetterCorePoolLeakIT: baseline active={}, after 500 authUser calls active={}",
         baseline,
         active);
-    assertTrue(
-        active <= MAX_ALLOWED_ACTIVE,
-        "Core pool active connections should stay bounded; got " + active);
+    assertEquals(
+        baseline,
+        active,
+        "Core pool active connections should return to baseline after a serial loop; got "
+            + active
+            + " (baseline "
+            + baseline
+            + ")");
   }
 }


### PR DESCRIPTION
> **Stacked on [#834](https://github.com/OWASP/SecurityShepherd/pull/834).** Retarget to `dev#536` after #834 lands.

## Summary

Carries the same `assertEquals(baseline, active)` tightening that #834 applied to `SetterCorePoolLeakIT` over to `GetterCorePoolLeakIT` (which #834 already touched for the `TestProperties.executeSql(log)` → `ensureSchemaReady + reseedTestData` swap, but didn't touch the assertion to keep that PR's scope tight).

## Why the old assertion was insufficient

The previous assertion was `active <= MAX_ALLOWED_ACTIVE` with `MAX_ALLOWED_ACTIVE = 32`. Two problems:

1. **The hardcoded ceiling exceeds the pool max.** The core pool defaults to `maximumPoolSize=20` (`database.properties.example`, set in #819). A value of 21–32 is already pool saturation, not a healthy bounded pool.
2. **Hikari throws long before active hits 32.** With `connectionTimeout=5000ms`, once the pool is saturated the next `getConnection()` call throws `SQLTransientConnectionException` after 5s. The loop swallows the exception and moves on, so the test stays green while the pool is effectively dead.

The loop is serial — one thread, one borrow at a time — so a non-leaking pool **must** return `active` to baseline (typically 0) after every iteration. Asserting equality detects leaks deterministically.

## Changes

- `assertTrue(active <= MAX_ALLOWED_ACTIVE, ...)` → `assertEquals(baseline, active, ...)`
- Drop the `MAX_ALLOWED_ACTIVE` constant.
- Add a Javadoc paragraph on the assertion choice.

## Test plan

- [x] `mvn -Dit.test=GetterCorePoolLeakIT failsafe:integration-test` passes (1/1)