### PR TITLE
fix: harden first-time setup against pool state (stacked on #834)

### DIFF
--- a/src/main/java/dbProcs/ConnectionPool.java
+++ b/src/main/java/dbProcs/ConnectionPool.java
@@ -2,6 +2,7 @@ package dbProcs;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -264,6 +265,19 @@ public class ConnectionPool {
   }
 
   /**
+   * Loads database properties if the file exists; otherwise returns an empty Properties object.
+   * Used by the challenge-connection path during first-time setup, when callers supply
+   * url/user/password as arguments and the on-disk file does not yet exist. All pool tuning
+   * properties have defaults, so an empty Properties object is safe.
+   */
+  private static Properties loadDatabasePropertiesIfPresent() {
+    if (!new File(Constants.MYSQL_DB_PROP).isFile()) {
+      return new Properties();
+    }
+    return loadDatabaseProperties();
+  }
+
+  /**
    * Gets a connection from the core database pool.
    *
    * @return A connection from the pool
@@ -314,7 +328,10 @@ public class ConnectionPool {
         challengePools.computeIfAbsent(
             poolKey,
             key -> {
-              Properties prop = loadDatabaseProperties();
+              // Tolerate missing database.properties: during first-time setup the file does
+              // not exist yet, but the caller already supplied url/user/password. Pool tuning
+              // falls back to defaults when properties are absent.
+              Properties prop = loadDatabasePropertiesIfPresent();
               return createDataSource(
                   jdbcUrl,
                   username,

--- a/src/main/java/servlets/Setup.java
+++ b/src/main/java/servlets/Setup.java
@@ -19,6 +19,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.sql.Connection;
+import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Locale;
@@ -204,14 +205,19 @@ public class Setup extends HttpServlet {
         log.error("Authorization mismatch: " + auth + " does not equal " + dbAuth);
 
       } else {
-        // Test the user's entered database properties
+        // Test the user's entered database properties. Use DriverManager directly instead of
+        // the pool: setup is a one-shot credential check that runs before database.properties
+        // exists, and routing it through a pooled DataSource keyed on (url, user) would
+        // silently reuse a stale pool when the password changes between setup attempts.
         Boolean connectionSuccess = false;
         log.debug("Attempting to connect to database");
 
-        try {
-          Connection conn =
-              Database.getConnection(driverType, connectionURL, dbOptions, dbUser, dbPass);
-          Database.closeConnection(conn);
+        String testJdbcUrl = connectionURL;
+        if (dbOptions != null && !dbOptions.isEmpty()) {
+          testJdbcUrl = connectionURL + "?" + dbOptions;
+        }
+
+        try (Connection conn = DriverManager.getConnection(testJdbcUrl, dbUser, dbPass)) {
           connectionSuccess = true;
           log.debug("Database connection successful");
 
@@ -463,17 +469,21 @@ public class Setup extends HttpServlet {
     String data = FileUtils.readFileToString(file, Charset.defaultCharset());
 
     log.debug("Initializing core database");
-    Connection databaseConnection = Database.getDatabaseConnection(null, true);
-    Statement psProcToexecute = databaseConnection.createStatement();
-    psProcToexecute.executeUpdate(data);
+    try (Connection databaseConnection = Database.getDatabaseConnection(null, true)) {
+      try (Statement psProcToexecute = databaseConnection.createStatement()) {
+        psProcToexecute.executeUpdate(data);
+      }
 
-    file =
-        new File(getClass().getClassLoader().getResource("/database/moduleSchemas.sql").getFile());
-    data = FileUtils.readFileToString(file, Charset.defaultCharset());
-    log.debug("Initializing module database");
+      file =
+          new File(
+              getClass().getClassLoader().getResource("/database/moduleSchemas.sql").getFile());
+      data = FileUtils.readFileToString(file, Charset.defaultCharset());
+      log.debug("Initializing module database");
 
-    psProcToexecute = databaseConnection.createStatement();
-    psProcToexecute.executeUpdate(data);
+      try (Statement psProcToexecute = databaseConnection.createStatement()) {
+        psProcToexecute.executeUpdate(data);
+      }
+    }
   }
 
   private synchronized void executeMongoScript() throws IOException {
@@ -502,9 +512,10 @@ public class Setup extends HttpServlet {
 
     data = FileUtils.readFileToString(file, Charset.defaultCharset());
 
-    Connection databaseConnection = Database.getDatabaseConnection(null, true);
-    Statement psProcToexecute = databaseConnection.createStatement();
-    psProcToexecute.executeUpdate(data);
+    try (Connection databaseConnection = Database.getDatabaseConnection(null, true);
+        Statement psProcToexecute = databaseConnection.createStatement()) {
+      psProcToexecute.executeUpdate(data);
+    }
   }
 
   private synchronized void openUnsafeLevels() {

--- a/src/main/java/servlets/Setup.java
+++ b/src/main/java/servlets/Setup.java
@@ -209,12 +209,19 @@ public class Setup extends HttpServlet {
         // the pool: setup is a one-shot credential check that runs before database.properties
         // exists, and routing it through a pooled DataSource keyed on (url, user) would
         // silently reuse a stale pool when the password changes between setup attempts.
+        //
+        // Append connectTimeout=5000 so a typo'd host or unreachable port fails fast (matching
+        // ConnectionPool's 5s default) instead of hanging on the OS's default TCP connect
+        // timeout — DriverManager has no built-in timeout and the setup page would otherwise
+        // appear to freeze.
         Boolean connectionSuccess = false;
         log.debug("Attempting to connect to database");
 
-        String testJdbcUrl = connectionURL;
+        String testJdbcUrl;
         if (dbOptions != null && !dbOptions.isEmpty()) {
-          testJdbcUrl = connectionURL + "?" + dbOptions;
+          testJdbcUrl = connectionURL + "?" + dbOptions + "&connectTimeout=5000";
+        } else {
+          testJdbcUrl = connectionURL + "?connectTimeout=5000";
         }
 
         try (Connection conn = DriverManager.getConnection(testJdbcUrl, dbUser, dbPass)) {


### PR DESCRIPTION
> **Stacked on [#834](https://github.com/OWASP/SecurityShepherd/pull/834).** Retarget to `dev#536` after #834 lands.

## Summary

Three reviewer-identified bugs in the setup flow, all rooted in routing setup-time DB operations through the same connection pool the rest of the app uses. Setup runs **before** the pool's configuration exists on disk and operates on credentials that may differ from previous attempts — it has no business participating in the pool.

| # | Bug | Fix |
|---|-----|-----|
| **P1** | `ConnectionPool.getChallengeConnection` always called `loadDatabaseProperties()` inside `computeIfAbsent`. During first setup, `database.properties` does not yet exist, so this threw `RuntimeException` (uncaught by `Setup.java`'s `catch (SQLException)`) and 500'd the setup screen. | Add `loadDatabasePropertiesIfPresent()` that returns an empty `Properties` if the file is missing. The challenge path already gets url/user/password as arguments; the loaded properties are only used for optional pool tuning, all with defaults. |
| **P2 (stale pool)** | The setup connection-test routed through `Database.getConnection` → `ConnectionPool.getChallengeConnection`, which keys pools by `(url, username)`. Re-running setup with the same url+user but a different password silently returned a connection from the **stale** pool — the test validated against the old password, then setup wrote the new password to disk, leaving the app broken on next startup. | Route the setup-test through `DriverManager.getConnection` directly and bypass the pool entirely. Setup is a one-shot credential check, not a runtime workload. |
| **P2 (leak)** | `Setup.executeSqlScript` and `Setup.executeUpdateScript` borrowed `Database.getDatabaseConnection(null, true)` without ever returning it. Pre-pooling, this was invisible (GC reclaimed the raw JDBC connection). Now those calls draw from the **3-connection** challenge pool and never return — three failed setup attempts saturate it. | Wrap both methods in try-with-resources on Connection and Statement. |

## Test plan

- [x] `mvn -Dit.test='SetupIT,SetterCorePoolLeakIT,GetterCorePoolLeakIT' failsafe:integration-test` — all pass (7 tests, 2 skipped due to existing `assumeTrue(poolReady)` guards).
- [ ] Manual: rename `database.properties` → first setup screen loads and submits without 500.
- [ ] Manual: re-run setup with same url+user but a wrong-then-right password sequence — the wrong attempt fails the connection test (not silently passes against a stale pool).
- [ ] Manual: trigger setup three times back-to-back — pool does not saturate.