### PR TITLE
test: bootstrap DB props in DowngradeAdminsIT and DeletePlayersIT

### DIFF
--- a/src/it/java/servlets/admin/userManagement/DeletePlayersIT.java
+++ b/src/it/java/servlets/admin/userManagement/DeletePlayersIT.java
@@ -9,6 +9,7 @@ import java.sql.SQLException;
 import javax.servlet.ServletException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -28,6 +29,17 @@ public class DeletePlayersIT {
   private MockHttpServletRequest request;
   private MockHttpServletResponse response;
   private static String lang = "en_GB";
+
+  /** Creates DB or Restores DB to Factory Defaults before running tests */
+  @BeforeAll
+  public static void resetDatabase() throws IOException, SQLException {
+    TestProperties.setTestPropertiesFileDirectory(log);
+
+    TestProperties.createMysqlResource();
+
+    TestProperties.ensureSchemaReady(log);
+    TestProperties.reseedTestData();
+  }
 
   @BeforeEach
   public void setUp() {

--- a/src/it/java/servlets/admin/userManagement/DowngradeAdminsIT.java
+++ b/src/it/java/servlets/admin/userManagement/DowngradeAdminsIT.java
@@ -4,8 +4,11 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import dbProcs.Getter;
 import dbProcs.Setter;
+import java.io.IOException;
+import java.sql.SQLException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -21,6 +24,17 @@ public class DowngradeAdminsIT {
   private MockHttpServletRequest request;
   private MockHttpServletResponse response;
   private static String lang = "en_GB";
+
+  /** Creates DB or Restores DB to Factory Defaults before running tests */
+  @BeforeAll
+  public static void resetDatabase() throws IOException, SQLException {
+    TestProperties.setTestPropertiesFileDirectory(log);
+
+    TestProperties.createMysqlResource();
+
+    TestProperties.ensureSchemaReady(log);
+    TestProperties.reseedTestData();
+  }
 
   @BeforeEach
   public void setUp() {


### PR DESCRIPTION
## Summary

Two IT files under `src/it/java/servlets/admin/userManagement/` were calling into `Getter`/`Setter` without first writing the test `database.properties` file. The other 42 IT files in the suite do this via a standard `@BeforeAll` block. These two were missed.

**Pre-pool (#816)** this worked: application code read the properties file lazily on every DB call, and the test runtime arranged for the file to exist via other means.

**Post-pool**, `ConnectionPool.initialize()` runs **once per JVM** on the first `getConnection()` call and reads the props file exactly once. If the file is missing, the pool is marked unusable for the entire JVM and every subsequent test in that fork throws `Connection pool not available`.

In CI this looked like a flood of FATAL `FileNotFoundException` stack traces drowning out the actual leak signal we're hunting in the integration-tests job. Example seen on the post-#834 dev#536 run:

```
FileNotFoundException: /home/runner/.../target/test-classes/conf/database.properties (No such file or directory)
  at ConnectionPool.loadDatabaseProperties(ConnectionPool.java:257)
  at ConnectionPool.initialize(ConnectionPool.java:73)
  ...
  at servlets.admin.userManagement.DowngradeAdminsIT.testWithAdminAuthValidUser
```

## Attribution

This is a **latent IT-bootstrap gap that #816's pool-init model surfaced**, not a regression from any specific recent PR:

- #816 changed pool init from per-call (lazy file read) to per-JVM (one-shot file read).
- #826 (JUnit 4 → 5 migration) preserved the pre-existing setup verbatim; didn't touch this.
- #832 (DDL once / per-class reseed) updated 35 ITs that *already had* the bootstrap; didn't add it to ITs that lacked it.

A strategic fix would be to make `TestProperties` auto-bootstrap on any first DB call from a test JVM, but that is much bigger scope than needed.

## Changes

| File | Change |
|------|--------|
| `DowngradeAdminsIT.java` | Add `@BeforeAll resetDatabase()` with `createMysqlResource + ensureSchemaReady + reseedTestData`. Keep existing `@BeforeEach` (per-test mock request/response reset). |
| `DeletePlayersIT.java` | Same. |

26 lines added across the two files. No behavior change beyond the bootstrap.

## Verification

```
mvn -Dit.test='DowngradeAdminsIT,DeletePlayersIT' failsafe:integration-test
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
```

All 8 tests now pass (4 per file). Before this fix every one of them FATAL'd at pool init.

## Why this matters now

After #834 and #836 closed the high-impact core-pool leaks in `Setter` and `Setup`, the integration-tests job on `dev#536` still failed — but with two distinct failure modes interleaved:

1. **Real remaining leaks** in challenge servlets / other paths (the actual signal).
2. **This IT-bootstrap bug** producing hundreds of lines of FATAL log per failing test method (noise).

Removing the noise lets us see which challenge family to tackle next.

## Test plan

- [x] Local: 8 tests pass across both files
- [ ] CI integration-tests run cleaner (no `Connection pool not available` cascade from these two classes)