### PR TITLE
fix: return DB connections from Getter ResultSet methods (CachedRowSet)

### DIFF
--- a/src/it/java/dbProcs/GetterIT.java
+++ b/src/it/java/dbProcs/GetterIT.java
@@ -2502,7 +2502,8 @@ public class GetterIT {
     try {
       String classId = findCreateClassId("playersByClass");
       String userName = new String("playersByClass");
-      for (int i = 0; i <= 9; i++) {
+      int expectedPlayerCount = 10;
+      for (int i = 0; i < expectedPlayerCount; i++) {
         if (verifyTestUser(applicationRoot, userName + i, userName + i, classId)) {
           log.debug("Created User " + userName + i);
         } else {
@@ -2519,14 +2520,11 @@ public class GetterIT {
             fail("Incorrect User from Different Class Returned");
           }
         }
-        if (i != 9) {
-          if (i < 9) {
+        if (i != expectedPlayerCount) {
+          if (i < expectedPlayerCount) {
             fail("Too Few Users Returned");
-          } else if (i > 9) {
-            fail("Too Many Users Returned");
           } else {
-            log.fatal("Then surely the number WAS 9? How did this happen");
-            fail("Incorrect Amount of Users Returned");
+            fail("Too Many Users Returned");
           }
         }
       } catch (Exception e) {

--- a/src/main/java/dbProcs/Getter.java
+++ b/src/main/java/dbProcs/Getter.java
@@ -64,6 +64,15 @@ public class Getter {
   private static final int admiralCap = 999; // everything above Major is Admiral
 
   /**
+   * Safety cap on the number of rows materialized by {@link #getClassInfo}, {@link
+   * #getPlayersByClass}, and {@link #getAdmins}. These methods return a {@link
+   * javax.sql.rowset.CachedRowSet}, which holds every row in memory. Realistic workloads are well
+   * under this limit (tens to a few hundred per call); the cap exists to fail fast on a runaway
+   * query rather than OOM the JVM. Tracked for proper bounded-collection conversion in #839.
+   */
+  private static final int MAX_ROWSET_ROWS = 10_000;
+
+  /**
    * This method hashes the user submitted password and sends it to the database. The database does
    * the rest of the work, including Brute Force prevention.
    *
@@ -617,13 +626,15 @@ public class Getter {
     ResultSet result = null;
     log.debug("*** Getter.getClassInfo (All Classes) ***");
     try (Connection conn = Database.getCoreConnection(ApplicationRoot);
-        CallableStatement callstmt = conn.prepareCall("call classesGetData()");
-        ResultSet resultSet = callstmt.executeQuery()) {
-      log.debug("Gathering classesGetData ResultSet");
-      CachedRowSet rowSet = RowSetProvider.newFactory().createCachedRowSet();
-      rowSet.populate(resultSet);
-      rowSet.beforeFirst(); // populate() leaves the cursor after the last row
-      result = rowSet;
+        CallableStatement callstmt = conn.prepareCall("call classesGetData()")) {
+      callstmt.setMaxRows(MAX_ROWSET_ROWS);
+      try (ResultSet resultSet = callstmt.executeQuery()) {
+        log.debug("Gathering classesGetData ResultSet");
+        CachedRowSet rowSet = RowSetProvider.newFactory().createCachedRowSet();
+        rowSet.populate(resultSet);
+        rowSet.beforeFirst(); // populate() leaves the cursor after the last row
+        result = rowSet;
+      }
       log.debug("Returning Result Set from classesGetData");
     } catch (SQLException e) {
       log.error("Could not execute query: " + e.toString());
@@ -1767,6 +1778,7 @@ public class Getter {
     String sql = (classId != null) ? "call playersByClass(?)" : "call playersWithoutClass()";
     try (Connection conn = Database.getCoreConnection(ApplicationRoot);
         CallableStatement callstmt = conn.prepareCall(sql)) {
+      callstmt.setMaxRows(MAX_ROWSET_ROWS);
       if (classId != null) {
         log.debug("Gathering playersByClass ResultSet");
         callstmt.setString(1, classId);
@@ -2288,13 +2300,15 @@ public class Getter {
     ResultSet result = null;
     log.debug("*** Getter.adminGetAll () ***");
     try (Connection conn = Database.getCoreConnection(ApplicationRoot);
-        CallableStatement callstmt = conn.prepareCall("call adminGetAll()");
-        ResultSet resultSet = callstmt.executeQuery()) {
-      log.debug("Gathering adminGetAll ResultSet");
-      CachedRowSet rowSet = RowSetProvider.newFactory().createCachedRowSet();
-      rowSet.populate(resultSet);
-      rowSet.beforeFirst(); // populate() leaves the cursor after the last row
-      result = rowSet;
+        CallableStatement callstmt = conn.prepareCall("call adminGetAll()")) {
+      callstmt.setMaxRows(MAX_ROWSET_ROWS);
+      try (ResultSet resultSet = callstmt.executeQuery()) {
+        log.debug("Gathering adminGetAll ResultSet");
+        CachedRowSet rowSet = RowSetProvider.newFactory().createCachedRowSet();
+        rowSet.populate(resultSet);
+        rowSet.beforeFirst(); // populate() leaves the cursor after the last row
+        result = rowSet;
+      }
       log.debug("Returning Result Set from adminGetAll");
 
     } catch (SQLException e) {

--- a/src/main/java/dbProcs/Getter.java
+++ b/src/main/java/dbProcs/Getter.java
@@ -13,6 +13,8 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Locale;
 import java.util.ResourceBundle;
+import javax.sql.rowset.CachedRowSet;
+import javax.sql.rowset.RowSetProvider;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;
@@ -614,12 +616,14 @@ public class Getter {
   public static ResultSet getClassInfo(String ApplicationRoot) {
     ResultSet result = null;
     log.debug("*** Getter.getClassInfo (All Classes) ***");
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
-
-      CallableStatement callstmt = conn.prepareCall("call classesGetData()");
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot);
+        CallableStatement callstmt = conn.prepareCall("call classesGetData()");
+        ResultSet resultSet = callstmt.executeQuery()) {
       log.debug("Gathering classesGetData ResultSet");
-      result = callstmt.executeQuery();
+      CachedRowSet rowSet = RowSetProvider.newFactory().createCachedRowSet();
+      rowSet.populate(resultSet);
+      rowSet.beforeFirst(); // populate() leaves the cursor after the last row
+      result = rowSet;
       log.debug("Returning Result Set from classesGetData");
     } catch (SQLException e) {
       log.error("Could not execute query: " + e.toString());
@@ -1760,24 +1764,22 @@ public class Getter {
     ResultSet result = null;
     log.debug("*** Getter.getPlayersByClass (Single Class) ***");
     log.debug("classId: '" + classId + "'");
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
-
-      CallableStatement callstmt = null;
+    String sql = (classId != null) ? "call playersByClass(?)" : "call playersWithoutClass()";
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot);
+        CallableStatement callstmt = conn.prepareCall(sql)) {
       if (classId != null) {
         log.debug("Gathering playersByClass ResultSet");
-        callstmt = conn.prepareCall("call playersByClass(?)");
         callstmt.setString(1, classId);
-        log.debug("Returning Result Set from playersByClass");
       } else {
         log.debug("Gathering playersWithoutClass ResultSet");
-        callstmt = conn.prepareCall("call playersWithoutClass()");
-        log.debug("Returning Result Set from playersByClass");
       }
-      ResultSet resultSet = callstmt.executeQuery();
-      result = resultSet;
-      resultSet.next();
-
+      try (ResultSet resultSet = callstmt.executeQuery()) {
+        CachedRowSet rowSet = RowSetProvider.newFactory().createCachedRowSet();
+        rowSet.populate(resultSet);
+        rowSet.beforeFirst(); // populate() leaves the cursor after the last row
+        result = rowSet;
+      }
+      log.debug("Returning Result Set from playersByClass");
     } catch (SQLException e) {
       log.error("Could not execute query: " + e.toString());
       result = null;
@@ -2285,12 +2287,14 @@ public class Getter {
   public static ResultSet getAdmins(String ApplicationRoot) {
     ResultSet result = null;
     log.debug("*** Getter.adminGetAll () ***");
-    try {
-      Connection conn = Database.getCoreConnection(ApplicationRoot);
-
-      CallableStatement callstmt = conn.prepareCall("call adminGetAll()");
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot);
+        CallableStatement callstmt = conn.prepareCall("call adminGetAll()");
+        ResultSet resultSet = callstmt.executeQuery()) {
       log.debug("Gathering adminGetAll ResultSet");
-      result = callstmt.executeQuery();
+      CachedRowSet rowSet = RowSetProvider.newFactory().createCachedRowSet();
+      rowSet.populate(resultSet);
+      rowSet.beforeFirst(); // populate() leaves the cursor after the last row
+      result = rowSet;
       log.debug("Returning Result Set from adminGetAll");
 
     } catch (SQLException e) {


### PR DESCRIPTION
## Summary

Three `Getter` methods returned a live JDBC `ResultSet` while leaving their owning `Connection` and `CallableStatement` borrowed from the core Hikari pool:

- `Getter.getClassInfo(String)` (all classes)
- `Getter.getPlayersByClass(String, String)`
- `Getter.getAdmins(String)`

The caller could not return them because `Connection` ownership was private to the method. Under load this slowly bled the core pool until CI hit:

```
CorePool - Connection is not available, request timed out after 5005ms
```

These are the same family of leak as #817 and #834 but with a structural twist — the API contract returns a `ResultSet`, not a value, so you can't just close inside the method.

## Fix

Materialize results into a `javax.sql.rowset.CachedRowSet` inside try-with-resources on `Connection` / `CallableStatement` / `ResultSet`. The caller still receives a `ResultSet`-compatible object, but DB resources are released immediately.

Result sizes here are all bounded in practice — one row per class / admin / player-in-a-class — so the in-memory cost is negligible.

`CachedRowSet.populate()` leaves the cursor after the last row, so each method calls `beforeFirst()` before returning. This way callers that do `while (rs.next())` without a prior `beforeFirst()` see all rows.

## Safety cap on materialization (addressing Copilot review)

Copilot pointed out that the backing stored procedures (`classesGetData`, `playersByClass`, `playersWithoutClass`, `adminGetAll`) have no `LIMIT`, so a runaway query — accidental or malicious — could OOM the JVM when the entire result set is materialized.

Added `CallableStatement.setMaxRows(MAX_ROWSET_ROWS)` where `MAX_ROWSET_ROWS = 10_000`. Well above realistic Security Shepherd workloads (class rosters of tens to a few hundred), but a hard ceiling against pathological cases.

Proper structural fix — return `List<DTO>` instead of `ResultSet`-typed cursors — is tracked in **#839** as part of the broader DAO refactor scope. The cap is a guardrail, not a substitute for that work.

## Latent bugs surfaced

1. **`getPlayersByClass` had a one-row cursor advance** (`resultSet.next()` before returning). The only production caller, `GetPlayersByClass.playersInOptionTags`, does `beforeFirst()` then `while (next())` so it iterates all rows — the advance was masked. The IT `testGetPlayersByClass` didn't call `beforeFirst()` and so counted N-1 rows; the test compensated by creating 10 users and expecting 9. Production semantics is "all rows"; the test was wrong. Fix the test to create 10 and expect 10.

2. The IT had an unreachable else branch (`if (i != 9) { if (i < 9) ... else if (i > 9) ... else { fail("Then surely the number WAS 9?") } }`). Removed.

## Verification

```
mvn -Dit.test='GetterCorePoolLeakIT,SetterCorePoolLeakIT,GetterIT#testGetPlayersByClass+testGetAdmins+testGetClassInfoString+testGetClassInfoStringString' \
    failsafe:integration-test failsafe:verify -DskipUnitTests
```

All 7 tests pass. `mvn verify` clean, `google-java-format` clean, `git diff --check` clean.

## Stack

Independent of #837 (the IT bootstrap fix). Both target `dev#536`; merge order is whichever lands first.

## Follow-up

- **#839** — convert ResultSet-returning Getter methods to bounded collections (DAO refactor follow-up; revisits the `setMaxRows` cap once API uses `List<DTO>`).