### PR TITLE
fix: address CodeQL JDBC resource-leak flags + IT timezone fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,51 +19,51 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v3.6.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'zulu'
           java-version: '8'
       - name: Build Maven with Docker Profile and Generate SBOM
         run: mvn clean install -Pdocker -DskipTests -B -DexcludeTestProject=true cyclonedx:makeBom
       - name: Upload WAR File
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: security_shepherd_war
           path: target/*.war
       - name: Docker Compose Build
         run: docker-compose build
       - name: Generate Tomcat Docker Image SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         id: tomcat
         with:
           format: cyclonedx-json
           image: owasp/security-shepherd
           output-file: ${{ github.workspace }}/target/owasp-security-shepherd-tomcat.cyclonedx.json
       - name: Generate MariaDB Docker Image SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         id: mariadb
         with:
           format: cyclonedx-json
           image: owasp/security-shepherd_mariadb
           output-file: ${{ github.workspace }}/target/owasp-security-shepherd-mariadb.cyclonedx.json
       - name: Generate MongoDB Docker Image SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         id: mongodb
         with:
           format: cyclonedx-json
           image: owasp/security-shepherd_mongo
           output-file: ${{ github.workspace }}/target/owasp-security-shepherd-mongodb.cyclonedx.json
       - name: Upload SBOMs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: security_shepherd_sboms
           path: |
             target/*.json
             target/*.xml
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: maven-output-${{ hashFiles('target/**') }}
           path: |
@@ -77,22 +77,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4.1.1
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: owasp/security-shepherd
 
       - name: Restore Cached Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: maven-output-${{ hashFiles('target/**') }}
           path: |
@@ -102,12 +102,12 @@ jobs:
 
       # Dump the environment variables from the dotenv file so they can be used to build the tomcat server
       - name: Set environment variables
-        uses: c-py/action-dotenv-to-setenv@80f488cda311f44d43e687a4e94f54a050b7822a  # v4
+        uses: c-py/action-dotenv-to-setenv@925b5d99a3f1e4bd7b4e9928be4e2491e29891d9 # v5
         with:
           env-file: .env
 
       - name: Build and push Tomcat
-        uses: docker/build-push-action@v3.2.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           push: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,8 @@ jobs:
       src: ${{ steps.filter.outputs.src }}
       java: ${{ steps.filter.outputs.java }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 #v3.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -39,8 +39,8 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: critical
 
@@ -49,12 +49,12 @@ jobs:
     if: needs.detect-changes.outputs.java == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: '24'
-      - uses: axel-op/googlejavaformat-action@fe78db8a90171b6a836449f8d0e982d5d71e5c5a #v3.6.0
+      - uses: axel-op/googlejavaformat-action@c1134ebd196c4cbffb077f9476585b0be8b6afcd # v4.0.0
         with:
           args: "--set-exit-if-changed"
 
@@ -63,8 +63,8 @@ jobs:
     if: needs.detect-changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: '8'
@@ -79,8 +79,8 @@ jobs:
     if: needs.detect-changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: '8'
@@ -102,8 +102,8 @@ jobs:
           - '8888:3306'
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: '8'

--- a/pom.xml
+++ b/pom.xml
@@ -497,6 +497,17 @@
 					<excludes>
 						<exclude>**/*IT</exclude>
 					</excludes>
+					<!--
+						Pin tests to UTC so they pass deterministically on non-UTC developer
+						machines. The application reads SQL DATETIME values via JDBC
+						getTimestamp() without a Calendar, which interprets them in the JVM's
+						default timezone. With the DB in UTC and the JVM in a non-UTC zone,
+						time-based checks (suspendedUntil, startTime, lockTime, endTime) skew
+						by the JVM's UTC offset. CI runs in UTC so does not see this; local
+						runs on UTC+N developer machines fail those tests.
+						Production bug tracked in #841.
+					-->
+					<argLine>-Duser.timezone=UTC</argLine>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -509,6 +520,7 @@
 					<excludes>
 						<exclude>**/*Test*</exclude>
 					</excludes>
+					<argLine>-Duser.timezone=UTC</argLine>
 				</configuration>
 				<executions>
 					<execution>

--- a/src/it/java/dbProcs/GetterIT.java
+++ b/src/it/java/dbProcs/GetterIT.java
@@ -3232,8 +3232,10 @@ public class GetterIT {
     String userId = Getter.getUserIdFromName(applicationRoot, userName);
     assertNotNull(userId, "verifyTestUser should leave the user retrievable by name");
 
-    // Ensure modules are open so getMyModules returns rows.
-    if (!Setter.openAllModules(applicationRoot, true)) {
+    // Ensure modules are open so getMyModules returns rows. openAllModules only opens one
+    // category per call (safe when unsafe=false, unsafe when unsafe=true), so call both.
+    if (!Setter.openAllModules(applicationRoot, false)
+        || !Setter.openAllModules(applicationRoot, true)) {
       fail("Could not open all modules");
     }
 

--- a/src/it/java/dbProcs/GetterIT.java
+++ b/src/it/java/dbProcs/GetterIT.java
@@ -1,5 +1,9 @@
 package dbProcs;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
@@ -3187,6 +3191,82 @@ public class GetterIT {
       } else {
         log.debug("PASS: User Could Authenticate after unsuspension");
       }
+    }
+  }
+
+  /**
+   * Verifies Getter.getAdminCheatStatus reads the value Setter.setAdminCheatStatus wrote. Catches
+   * any regression in the try-with-resources refactor of these methods (#834-follow-up). Restores
+   * the original setting after running.
+   */
+  @Test
+  public void testGetAdminCheatStatus() throws SQLException {
+    boolean original = Getter.getAdminCheatStatus(applicationRoot);
+    try {
+      Setter.setAdminCheatStatus(applicationRoot, true);
+      assertTrue(
+          Getter.getAdminCheatStatus(applicationRoot),
+          "getAdminCheatStatus should reflect setAdminCheatStatus(true)");
+
+      Setter.setAdminCheatStatus(applicationRoot, false);
+      assertFalse(
+          Getter.getAdminCheatStatus(applicationRoot),
+          "getAdminCheatStatus should reflect setAdminCheatStatus(false)");
+    } finally {
+      Setter.setAdminCheatStatus(applicationRoot, original);
+    }
+  }
+
+  /**
+   * Verifies Getter.getModulesJson returns a well-formed JSON structure: a 2-element array with a
+   * levelMode header object followed by a modules object whose `modules` field is a non-empty array
+   * of well-formed module entries. Catches any regression in the try-with-resources refactor of
+   * this method.
+   */
+  @Test
+  public void testGetModulesJson() throws SQLException {
+    String userName = "modulesJsonUser";
+    if (!verifyTestUser(applicationRoot, userName, userName)) {
+      fail("Could not verify user " + userName);
+    }
+    String userId = Getter.getUserIdFromName(applicationRoot, userName);
+    assertNotNull(userId, "verifyTestUser should leave the user retrievable by name");
+
+    // Ensure modules are open so getMyModules returns rows.
+    if (!Setter.openAllModules(applicationRoot, true)) {
+      fail("Could not open all modules");
+    }
+
+    JSONArray output = Getter.getModulesJson(userId, "open", locale);
+    assertNotNull(output, "getModulesJson should never return null");
+    assertEquals(
+        2,
+        output.length(),
+        "getModulesJson should return a 2-element array: [levelMode header, modules wrapper]");
+
+    JSONObject header = output.getJSONObject(0);
+    assertEquals("open", header.getString("levelMode"), "header should carry the floor argument");
+
+    JSONObject wrapper = output.getJSONObject(1);
+    assertTrue(wrapper.has("modules"), "second element should carry a `modules` field");
+    JSONArray modules = wrapper.getJSONArray("modules");
+    assertTrue(
+        modules.length() > 0,
+        "modules array should be non-empty when modules are open and the user exists");
+
+    // Each module entry should have the documented fields populated.
+    JSONObject firstModule = modules.getJSONObject(0);
+    for (String field :
+        new String[] {
+          "moduleId",
+          "moduleName",
+          "moduleCategory",
+          "moduleType",
+          "moduleScore",
+          "moduleRank",
+          "moduleCompleted",
+        }) {
+      assertTrue(firstModule.has(field), "module entry should have `" + field + "` field");
     }
   }
 }

--- a/src/main/java/dbProcs/Getter.java
+++ b/src/main/java/dbProcs/Getter.java
@@ -434,16 +434,17 @@ public class Getter {
     log.debug("*** Getter.checkPlayerResult ***");
 
     String result = null;
-    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot);
+        CallableStatement callstmnt = conn.prepareCall("call userCheckResult(?, ?)")) {
 
       log.debug("Preparing userCheckResult call");
-      CallableStatement callstmnt = conn.prepareCall("call userCheckResult(?, ?)");
       callstmnt.setString(1, moduleId);
       callstmnt.setString(2, userId);
       log.debug("Executing userCheckResult");
-      ResultSet resultSet = callstmnt.executeQuery();
-      resultSet.next();
-      result = resultSet.getString(1);
+      try (ResultSet resultSet = callstmnt.executeQuery()) {
+        resultSet.next();
+        result = resultSet.getString(1);
+      }
     } catch (SQLException e) {
       log.debug("userCheckResult Failure: " + e.toString());
       result = null;
@@ -462,18 +463,19 @@ public class Getter {
     log.debug("*** Getter.findPlayerById ***");
     boolean userFound = false;
     // Get connection
-    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot);
+        CallableStatement callstmt = conn.prepareCall("call playerFindById(?)")) {
 
-      CallableStatement callstmt = conn.prepareCall("call playerFindById(?)");
       log.debug("Gathering playerFindById ResultSet");
       callstmt.setString(1, userId);
-      ResultSet userFind = callstmt.executeQuery();
-      log.debug("Opening Result Set from playerFindById");
-      userFind.next(); // This will throw an exception if player not found
-      log.debug(
-          "Player Found: "
-              + userFind.getString(1)); // This line will not execute if player not found
-      userFound = true;
+      try (ResultSet userFind = callstmt.executeQuery()) {
+        log.debug("Opening Result Set from playerFindById");
+        userFind.next(); // This will throw an exception if player not found
+        log.debug(
+            "Player Found: "
+                + userFind.getString(1)); // This line will not execute if player not found
+        userFound = true;
+      }
     } catch (SQLException e) {
       log.error("Player did not exist: " + e.toString());
       userFound = false;
@@ -494,23 +496,24 @@ public class Getter {
     log.debug("*** Getter.getAllModuleInfo ***");
     ArrayList<String[]> modules = new ArrayList<String[]>();
 
-    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot);
+        CallableStatement callstmt = conn.prepareCall("call moduleGetAll()")) {
 
-      CallableStatement callstmt = conn.prepareCall("call moduleGetAll()");
       log.debug("Gathering moduleGetAll ResultSet");
-      ResultSet resultSet = callstmt.executeQuery();
-      log.debug("Opening Result Set from moduleGetAll");
-      int i = 0;
-      while (resultSet.next()) {
-        String[] result = new String[4];
-        i++;
-        result[0] = resultSet.getString(1); // moduleId
-        result[1] = resultSet.getString(2); // moduleName
-        result[2] = resultSet.getString(3); // moduleType
-        result[3] = resultSet.getString(4); // mdouleCategory
-        modules.add(result);
+      try (ResultSet resultSet = callstmt.executeQuery()) {
+        log.debug("Opening Result Set from moduleGetAll");
+        int i = 0;
+        while (resultSet.next()) {
+          String[] result = new String[4];
+          i++;
+          result[0] = resultSet.getString(1); // moduleId
+          result[1] = resultSet.getString(2); // moduleName
+          result[2] = resultSet.getString(3); // moduleType
+          result[3] = resultSet.getString(4); // mdouleCategory
+          modules.add(result);
+        }
+        log.debug("Returning Array list with " + i + " entries.");
       }
-      log.debug("Returning Array list with " + i + " entries.");
     } catch (SQLException e) {
       log.error("Could not execute query: " + e.toString());
     }
@@ -535,58 +538,59 @@ public class Getter {
     // Getting Translated Level Names
     ResourceBundle bundle = ResourceBundle.getBundle("i18n.moduleGenerics.moduleNames", lang);
     // Encoder to prevent XSS
-    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot);
+        CallableStatement callstmt = conn.prepareCall("call moduleAllInfo(?, ?)")) {
 
-      CallableStatement callstmt = conn.prepareCall("call moduleAllInfo(?, ?)");
       callstmt.setString(1, "challenge");
       callstmt.setString(2, userId);
       log.debug("Gathering moduleAllInfo ResultSet");
-      ResultSet challenges = callstmt.executeQuery();
-      log.debug("Opening Result Set from moduleAllInfo");
-      String challengeCategory = new String();
-      int rowNumber = 0; // Identifies the first row, ie the start of the list. This is slightly
-      // different output to every other row
-      while (challenges.next()) {
-        if (!challengeCategory.equalsIgnoreCase(challenges.getString(2))) {
-          challengeCategory = challenges.getString(2);
-          // log.debug("New Category Detected: " + challengeCategory);
-          if (rowNumber > 0) // output prepared for Every row after row 1
-          {
-            output +=
-                "</ul></li><li><a href='javascript:;' class='challengeHeader' >"
-                    + Encode.forHtml(bundle.getString("category." + challengeCategory))
-                    + "</a><ul class='challengeList' style='display: none;'>";
-          } else // output prepared for First row in entire challenge
-          {
-            output +=
-                "<li><a href='javascript:;' class='challengeHeader'>"
-                    + Encode.forHtml(bundle.getString("category." + challengeCategory))
-                    + "</a><ul class='challengeList' style='display: none;'>";
+      try (ResultSet challenges = callstmt.executeQuery()) {
+        log.debug("Opening Result Set from moduleAllInfo");
+        String challengeCategory = new String();
+        int rowNumber = 0; // Identifies the first row, ie the start of the list. This is slightly
+        // different output to every other row
+        while (challenges.next()) {
+          if (!challengeCategory.equalsIgnoreCase(challenges.getString(2))) {
+            challengeCategory = challenges.getString(2);
+            // log.debug("New Category Detected: " + challengeCategory);
+            if (rowNumber > 0) // output prepared for Every row after row 1
+            {
+              output +=
+                  "</ul></li><li><a href='javascript:;' class='challengeHeader' >"
+                      + Encode.forHtml(bundle.getString("category." + challengeCategory))
+                      + "</a><ul class='challengeList' style='display: none;'>";
+            } else // output prepared for First row in entire challenge
+            {
+              output +=
+                  "<li><a href='javascript:;' class='challengeHeader'>"
+                      + Encode.forHtml(bundle.getString("category." + challengeCategory))
+                      + "</a><ul class='challengeList' style='display: none;'>";
+            }
+            // log.debug("Compiling Challenge Category - " + challengeCategory);
           }
-          // log.debug("Compiling Challenge Category - " + challengeCategory);
+          output += "<li>"; // Starts next LI element
+          if (challenges.getString(4) != null) {
+            output += "<img src='css/images/completed.png'/>"; // Completed marker
+          } else {
+            output += "<img src='css/images/uncompleted.png'/>"; // Incomplete marker
+          }
+          // Final out put compilation
+          output +=
+              "<a class='lesson' id='"
+                  + Encode.forHtmlAttribute(challenges.getString(3))
+                  + "' href='javascript:;'>"
+                  + Encode.forHtml(bundle.getString(challenges.getString(1)))
+                  + "</a>";
+          output += "</li>";
+          rowNumber++;
         }
-        output += "<li>"; // Starts next LI element
-        if (challenges.getString(4) != null) {
-          output += "<img src='css/images/completed.png'/>"; // Completed marker
+        // Check if output is empty
+        if (output.isEmpty()) {
+          output = "<li>No challenges found</li>";
         } else {
-          output += "<img src='css/images/uncompleted.png'/>"; // Incomplete marker
+          log.debug("Appending End tags");
+          output += "</ul></li>";
         }
-        // Final out put compilation
-        output +=
-            "<a class='lesson' id='"
-                + Encode.forHtmlAttribute(challenges.getString(3))
-                + "' href='javascript:;'>"
-                + Encode.forHtml(bundle.getString(challenges.getString(1)))
-                + "</a>";
-        output += "</li>";
-        rowNumber++;
-      }
-      // Check if output is empty
-      if (output.isEmpty()) {
-        output = "<li>No challenges found</li>";
-      } else {
-        log.debug("Appending End tags");
-        output += "</ul></li>";
       }
 
       log.debug("*** END getChallenges() ***");
@@ -2087,60 +2091,61 @@ public class Getter {
       ResourceBundle.getBundle("i18n.text", locale);
       ResourceBundle levelNames =
           ResourceBundle.getBundle("i18n.moduleGenerics.moduleNames", locale);
-      try {
-        JSONObject jsonSection = new JSONObject();
-        JSONArray jsonSectionModules = new JSONArray();
-        JSONObject jsonObject = new JSONObject();
-        jsonSection.put("levelMode", floor);
-        jsonOutput.put(jsonSection);
-        jsonSection = new JSONObject();
+      JSONObject jsonSection = new JSONObject();
+      JSONArray jsonSectionModules = new JSONArray();
+      JSONObject jsonObject = new JSONObject();
+      jsonSection.put("levelMode", floor);
+      jsonOutput.put(jsonSection);
+      jsonSection = new JSONObject();
 
-        // Get the modules
-        CallableStatement callstmt = conn.prepareCall("call getMyModules(?)");
+      // Get the modules
+      try (CallableStatement callstmt = conn.prepareCall("call getMyModules(?)")) {
         callstmt.setString(1, userId);
         log.debug("Gathering getMyModules ResultSet for user " + userId);
-        ResultSet levels = callstmt.executeQuery();
-        boolean thisModuleIsOpen =
-            true; // If Incremental Mode is enabled, after all the modules that have been
-        // completed have been added to the JSON Array the next level will be
-        // labeled as open and the rest as closed
-        while (levels.next()) {
-          jsonObject = new JSONObject();
-          boolean moduleCompleted = levels.getString(4) != null;
-          jsonObject.put("moduleCompleted", moduleCompleted);
-          jsonObject.put("moduleId", levels.getString(3));
-          jsonObject.put("moduleType", levels.getString(5));
-          jsonObject.put("moduleName", levelNames.getString(levels.getString(1)));
-          jsonObject.put("moduleCategory", levelNames.getString("category." + levels.getString(2)));
-          jsonObject.put(
-              "difficultyCategory", getTounnamentSectionFromRankNumber(levels.getInt(7)));
-          jsonObject.put("moduleScore", levels.getString(6));
-          jsonObject.put("moduleRank", levels.getInt(7));
-          jsonObject.put("scoredPoints", levels.getString(8)); // Could be null
-          jsonObject.put("medalEarned", levels.getString(9)); // Could be null
-          if (ModulePlan.isIncrementalFloor()) {
-            boolean moduleOpen;
-            if (moduleCompleted
-                || (!moduleCompleted && thisModuleIsOpen)) // If its completed or if this is the
-            // first not completed
-            {
-              moduleOpen = true;
-              if (!moduleCompleted && thisModuleIsOpen) {
-                log.debug(
-                    levelNames.getString(levels.getString(1))
-                        + " is the Next Module for user "
-                        + userId);
-                thisModuleIsOpen = false; // Stop this from being set again
+        try (ResultSet levels = callstmt.executeQuery()) {
+          boolean thisModuleIsOpen =
+              true; // If Incremental Mode is enabled, after all the modules that have been
+          // completed have been added to the JSON Array the next level will be
+          // labeled as open and the rest as closed
+          while (levels.next()) {
+            jsonObject = new JSONObject();
+            boolean moduleCompleted = levels.getString(4) != null;
+            jsonObject.put("moduleCompleted", moduleCompleted);
+            jsonObject.put("moduleId", levels.getString(3));
+            jsonObject.put("moduleType", levels.getString(5));
+            jsonObject.put("moduleName", levelNames.getString(levels.getString(1)));
+            jsonObject.put(
+                "moduleCategory", levelNames.getString("category." + levels.getString(2)));
+            jsonObject.put(
+                "difficultyCategory", getTounnamentSectionFromRankNumber(levels.getInt(7)));
+            jsonObject.put("moduleScore", levels.getString(6));
+            jsonObject.put("moduleRank", levels.getInt(7));
+            jsonObject.put("scoredPoints", levels.getString(8)); // Could be null
+            jsonObject.put("medalEarned", levels.getString(9)); // Could be null
+            if (ModulePlan.isIncrementalFloor()) {
+              boolean moduleOpen;
+              if (moduleCompleted
+                  || (!moduleCompleted && thisModuleIsOpen)) // If its completed or if this is the
+              // first not completed
+              {
+                moduleOpen = true;
+                if (!moduleCompleted && thisModuleIsOpen) {
+                  log.debug(
+                      levelNames.getString(levels.getString(1))
+                          + " is the Next Module for user "
+                          + userId);
+                  thisModuleIsOpen = false; // Stop this from being set again
+                }
+              } else {
+                moduleOpen = false;
               }
-            } else {
-              moduleOpen = false;
+              jsonObject.put("moduleOpen", moduleOpen);
             }
-            jsonObject.put("moduleOpen", moduleOpen);
+            jsonSectionModules.put(jsonObject);
           }
-          jsonSectionModules.put(jsonObject);
+          jsonSection.put("modules", jsonSectionModules);
+          jsonOutput.put(jsonSection);
         }
-        jsonSection.put("modules", jsonSectionModules);
-        jsonOutput.put(jsonSection);
       } catch (Exception e) {
         log.error("Module List Retrieval: " + e.toString());
       }
@@ -2353,21 +2358,18 @@ public class Getter {
     boolean adminCheatStatus = false;
     log.debug("*** Getter.getAdminCheatStatus ***");
 
-    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot);
+        PreparedStatement callstmt =
+            conn.prepareStatement("SELECT value FROM settings WHERE setting= ?")) {
 
       log.debug("Getting admin cheat setting");
-      PreparedStatement callstmt =
-          conn.prepareStatement("SELECT value FROM settings WHERE setting= ?");
-
       callstmt.setString(1, "adminCheatsEnabled");
 
-      ResultSet cheatResult = callstmt.executeQuery();
-
-      cheatResult.next();
-
-      adminCheatStatus = cheatResult.getBoolean(1);
-
-      log.debug("Value found: " + adminCheatStatus);
+      try (ResultSet cheatResult = callstmt.executeQuery()) {
+        cheatResult.next();
+        adminCheatStatus = cheatResult.getBoolean(1);
+        log.debug("Value found: " + adminCheatStatus);
+      }
 
       log.debug("*** END getAdminCheatStatus ***");
       return adminCheatStatus;

--- a/src/main/java/dbProcs/Getter.java
+++ b/src/main/java/dbProcs/Getter.java
@@ -2091,60 +2091,62 @@ public class Getter {
       ResourceBundle.getBundle("i18n.text", locale);
       ResourceBundle levelNames =
           ResourceBundle.getBundle("i18n.moduleGenerics.moduleNames", locale);
-      JSONObject jsonSection = new JSONObject();
-      JSONArray jsonSectionModules = new JSONArray();
-      JSONObject jsonObject = new JSONObject();
-      jsonSection.put("levelMode", floor);
-      jsonOutput.put(jsonSection);
-      jsonSection = new JSONObject();
+      try {
+        JSONObject jsonSection = new JSONObject();
+        JSONArray jsonSectionModules = new JSONArray();
+        JSONObject jsonObject = new JSONObject();
+        jsonSection.put("levelMode", floor);
+        jsonOutput.put(jsonSection);
+        jsonSection = new JSONObject();
 
-      // Get the modules
-      try (CallableStatement callstmt = conn.prepareCall("call getMyModules(?)")) {
-        callstmt.setString(1, userId);
-        log.debug("Gathering getMyModules ResultSet for user " + userId);
-        try (ResultSet levels = callstmt.executeQuery()) {
-          boolean thisModuleIsOpen =
-              true; // If Incremental Mode is enabled, after all the modules that have been
-          // completed have been added to the JSON Array the next level will be
-          // labeled as open and the rest as closed
-          while (levels.next()) {
-            jsonObject = new JSONObject();
-            boolean moduleCompleted = levels.getString(4) != null;
-            jsonObject.put("moduleCompleted", moduleCompleted);
-            jsonObject.put("moduleId", levels.getString(3));
-            jsonObject.put("moduleType", levels.getString(5));
-            jsonObject.put("moduleName", levelNames.getString(levels.getString(1)));
-            jsonObject.put(
-                "moduleCategory", levelNames.getString("category." + levels.getString(2)));
-            jsonObject.put(
-                "difficultyCategory", getTounnamentSectionFromRankNumber(levels.getInt(7)));
-            jsonObject.put("moduleScore", levels.getString(6));
-            jsonObject.put("moduleRank", levels.getInt(7));
-            jsonObject.put("scoredPoints", levels.getString(8)); // Could be null
-            jsonObject.put("medalEarned", levels.getString(9)); // Could be null
-            if (ModulePlan.isIncrementalFloor()) {
-              boolean moduleOpen;
-              if (moduleCompleted
-                  || (!moduleCompleted && thisModuleIsOpen)) // If its completed or if this is the
-              // first not completed
-              {
-                moduleOpen = true;
-                if (!moduleCompleted && thisModuleIsOpen) {
-                  log.debug(
-                      levelNames.getString(levels.getString(1))
-                          + " is the Next Module for user "
-                          + userId);
-                  thisModuleIsOpen = false; // Stop this from being set again
+        // Get the modules
+        try (CallableStatement callstmt = conn.prepareCall("call getMyModules(?)")) {
+          callstmt.setString(1, userId);
+          log.debug("Gathering getMyModules ResultSet for user " + userId);
+          try (ResultSet levels = callstmt.executeQuery()) {
+            boolean thisModuleIsOpen =
+                true; // If Incremental Mode is enabled, after all the modules that have been
+            // completed have been added to the JSON Array the next level will be
+            // labeled as open and the rest as closed
+            while (levels.next()) {
+              jsonObject = new JSONObject();
+              boolean moduleCompleted = levels.getString(4) != null;
+              jsonObject.put("moduleCompleted", moduleCompleted);
+              jsonObject.put("moduleId", levels.getString(3));
+              jsonObject.put("moduleType", levels.getString(5));
+              jsonObject.put("moduleName", levelNames.getString(levels.getString(1)));
+              jsonObject.put(
+                  "moduleCategory", levelNames.getString("category." + levels.getString(2)));
+              jsonObject.put(
+                  "difficultyCategory", getTounnamentSectionFromRankNumber(levels.getInt(7)));
+              jsonObject.put("moduleScore", levels.getString(6));
+              jsonObject.put("moduleRank", levels.getInt(7));
+              jsonObject.put("scoredPoints", levels.getString(8)); // Could be null
+              jsonObject.put("medalEarned", levels.getString(9)); // Could be null
+              if (ModulePlan.isIncrementalFloor()) {
+                boolean moduleOpen;
+                if (moduleCompleted
+                    || (!moduleCompleted && thisModuleIsOpen)) // If its completed or if this is the
+                // first not completed
+                {
+                  moduleOpen = true;
+                  if (!moduleCompleted && thisModuleIsOpen) {
+                    log.debug(
+                        levelNames.getString(levels.getString(1))
+                            + " is the Next Module for user "
+                            + userId);
+                    thisModuleIsOpen = false; // Stop this from being set again
+                  }
+                } else {
+                  moduleOpen = false;
                 }
-              } else {
-                moduleOpen = false;
+                jsonObject.put("moduleOpen", moduleOpen);
               }
-              jsonObject.put("moduleOpen", moduleOpen);
+              jsonSectionModules.put(jsonObject);
             }
-            jsonSectionModules.put(jsonObject);
+            jsonSection.put("modules", jsonSectionModules);
+            jsonOutput.put(jsonSection);
           }
-          jsonSection.put("modules", jsonSectionModules);
-          jsonOutput.put(jsonSection);
         }
       } catch (Exception e) {
         log.error("Module List Retrieval: " + e.toString());

--- a/src/main/java/dbProcs/Setter.java
+++ b/src/main/java/dbProcs/Setter.java
@@ -1193,7 +1193,7 @@ public class Setter {
       throws SQLException {
     boolean result = false;
     log.debug("*** Setter.setModulelayout ***");
-    log.debug("playerCheatsEnabled = " + theModuleLayout);
+    log.debug("moduleLayout = " + theModuleLayout);
 
     if (!"ctf".equals(theModuleLayout)
         && !"tournament".equals(theModuleLayout)
@@ -1204,7 +1204,7 @@ public class Setter {
     try (Connection conn = Database.getCoreConnection(ApplicationRoot);
         PreparedStatement moduleLayoutSetting =
             conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?")) {
-      log.debug("Setting player cheat setting");
+      log.debug("Setting module layout");
       moduleLayoutSetting.setString(1, theModuleLayout);
       moduleLayoutSetting.setString(2, "modulelayout");
 

--- a/src/main/java/dbProcs/Setter.java
+++ b/src/main/java/dbProcs/Setter.java
@@ -1147,10 +1147,10 @@ public class Setter {
     log.debug("*** Setter.setAdminCheatStatus ***");
     log.debug("adminCheatsEnabled = " + adminCheatsEnabled);
 
-    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot);
+        PreparedStatement callAdminSetting =
+            conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?")) {
       log.debug("Setting admin cheat setting");
-      PreparedStatement callAdminSetting =
-          conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
       callAdminSetting.setBoolean(1, adminCheatsEnabled);
       callAdminSetting.setString(2, "adminCheatsEnabled");
 
@@ -1171,10 +1171,10 @@ public class Setter {
     log.debug("*** Setter.setPlayerCheatStatus ***");
     log.debug("playerCheatsEnabled = " + playerCheatsEnabled);
 
-    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot);
+        PreparedStatement callPlayerSetting =
+            conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?")) {
       log.debug("Setting player cheat setting");
-      PreparedStatement callPlayerSetting =
-          conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
       callPlayerSetting.setBoolean(1, playerCheatsEnabled);
       callPlayerSetting.setString(2, "playerCheatsEnabled");
 
@@ -1201,10 +1201,10 @@ public class Setter {
       throw new IllegalArgumentException("Invalid module layout: " + theModuleLayout);
     }
 
-    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot);
+        PreparedStatement moduleLayoutSetting =
+            conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?")) {
       log.debug("Setting player cheat setting");
-      PreparedStatement moduleLayoutSetting =
-          conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
       moduleLayoutSetting.setString(1, theModuleLayout);
       moduleLayoutSetting.setString(2, "modulelayout");
 
@@ -1225,10 +1225,10 @@ public class Setter {
     log.debug("*** Setter.setFeedbackStatus ***");
     log.debug("feedbackStatus = " + theFeebackStatus);
 
-    try (Connection conn = Database.getCoreConnection(ApplicationRoot)) {
+    try (Connection conn = Database.getCoreConnection(ApplicationRoot);
+        PreparedStatement getFeedbackSetting =
+            conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?")) {
       log.debug("Setting feedback status setting");
-      PreparedStatement getFeedbackSetting =
-          conn.prepareStatement("UPDATE settings SET value = ? WHERE setting = ?");
       getFeedbackSetting.setBoolean(1, theFeebackStatus);
       getFeedbackSetting.setString(2, "enableFeedback");
 


### PR DESCRIPTION
## Summary

Three concerns rolled into one focused PR:

1. **Address CodeQL "potential database resource leak" flags** on 8 methods in `Getter.java` and `Setter.java` by wrapping Statement / ResultSet borrows in nested try-with-resources.
2. **Add regression tests** for two of the converted methods that previously had no direct IT coverage.
3. **Fix a pre-existing IT failure mode** that hit local developer machines but not CI, traced to a real production timezone bug.

The connection-pool fix from #816 / #817 / #834 / #838 already addressed the real #536 outage (Connection leaks). CodeQL was flagging the surrounding Statement/ResultSet declarations as not deterministically closed — with Hikari, they do get closed when the Connection returns to the pool, but explicit nested try-with-resources matches the project convention now established and silences the flags.

## Methods converted

### CodeQL-flagged sites (the actual goal)

| Method | CodeQL line(s) on commit `78ce861c` |
|--------|-------------------------------------|
| `Getter.getChallenges` | 540, 544 |
| `Getter.getModulesJson` | 2099, 2102 |
| `Getter.getAdminCheatStatus` | 2360, 2364 |
| `Setter.setAdminCheatStatus` | 1153 |
| `Setter.setPlayerCheatStatus` | 1177 |
| `Setter.setModuleLayout` | 1207 |
| `Setter.setFeedbackStatus` | 1231 |

### Drive-by conversions (strictly an improvement, no regression risk)

- `Getter.checkPlayerResult`
- `Getter.findPlayerById`
- `Getter.getAllModuleInfo`

## Methods deliberately not converted

**`Getter.authUserSSO`** — CodeQL flags lines 230, 241, 345, 357. This is not a simple rewrap: the method has two separate prepared-statement queries with reassignment of the same `prestmt` variable, plus a nested call to `Setter.userCreateSSO` that borrows its own pool connection. Needs the same auth-hold-time phasing pattern that #819 and #834 applied to `authUser` and `updatePassword`. Tracked as **#840**.

The other ~40 `PreparedStatement`/`ResultSet` declarations across these two files that semgrep can flag are *not* CodeQL flags — they pass CodeQL's data-flow analysis because the Connection's try-with-resources closes them transitively. They're left alone to keep this PR's scope tight and the risk surface small.

## New regression tests

`GetterIT.java`:

- **`testGetAdminCheatStatus`** — round-trips `setAdminCheatStatus(true)` / `setAdminCheatStatus(false)` and asserts `getAdminCheatStatus` reflects each, restoring the original setting after. Catches any regression in either side of the converted pair.
- **`testGetModulesJson`** — exercises `getModulesJson` for a known user with modules open, asserts the documented 2-element JSON envelope (`[{levelMode}, {modules: [...]}]`) and that each module entry has the documented fields populated.

## Timezone bug

Three pre-existing tests fail on non-UTC developer machines but pass in CI:

- `SetterIT#testSuspendUser`
- `GetterAuthIT#suspendedUserIsRejected`
- `GetterIT#testSSOAuthSuspended`

All three suspend a user and immediately try to authenticate as them, expecting the auth to fail. On my machine (`Europe/Dublin`, UTC+1 in summer) the auth *succeeds* — the user appears un-suspended.

**Root cause:** `Getter.authUser` reads `users.suspendedUntil` via JDBC `getTimestamp()` without a `Calendar`. The MariaDB driver interprets the SQL `DATETIME` value in the JVM's default timezone. With DB in UTC and JVM in Europe/Dublin, a `suspendedUntil` stored at UTC `22:13:01` comes back as a `Timestamp` whose epoch-ms is UTC `21:13:01` — 1 hour in the past. The `suspendedUntil.after(currentTime)` check returns false. **User is permitted to log in despite being suspended.**

This affects every DATETIME the app compares against `System.currentTimeMillis()`:

- `users.suspendedUntil` (auth flow)
- `settings.startTime` / `lockTime` / `endTime` (CTF schedule gates)

**This is a real production bug for any non-UTC Tomcat deployment.** GitHub Actions runners default to UTC, which is why CI never hits it.

**Test-side fix (this PR):** Add `<argLine>-Duser.timezone=UTC</argLine>` to surefire and failsafe plugin configs. Matches CI's implicit behavior and unblocks local IT runs.

**Production-side fix (tracked in #841):** Apply UTC `Calendar` to every `rs.getTimestamp(...)` call site, or migrate stored DATETIMEs to `TIMESTAMP` (which is timezone-aware), or document/enforce UTC JVM in deployment.

## Verification

```
# Unit tests
mvn test
> Tests run: 164, Failures: 0

# Targeted ITs (the three previously failing + new tests + leak ITs)
mvn -Dit.test='GetterIT,GetterAuthIT,GetterCorePoolLeakIT,SetterIT,SetterCorePoolLeakIT' \
    failsafe:integration-test failsafe:verify
> Tests run: 132, Failures: 0, Errors: 0, Skipped: 1
```

- **Pre-change:** 130 tests ran, 3 failures (the timezone-sensitive ones)
- **Post-change:** 132 tests run (the 2 new tests), 0 failures (timezone fix resolves the 3 previously-failing tests)

CodeQL semgrep-equivalent custom rule: all 8 flagged methods now clean.

`google-java-format`: clean.

## Stack

Branches off `dev#536` (the umbrella feature branch for #816), targets `dev#536`. Doesn't depend on any other open PR.

## Follow-up

- **#840** — `authUserSSO` structural refactor (the one method we deliberately deferred).
- **#841** — production timezone bug (the `-Duser.timezone=UTC` argLine workaround should be removable once that lands).