### PR TITLE
ci: scope push trigger to long-lived branches to dedupe PR runs (#850)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - master
       - dev
-      - "dev#*"
   pull_request:
     branches:
       - master


### PR DESCRIPTION
Fixes #850.

## Problem
A push to a `dev#*` branch with an open PR satisfied both the `push` and `pull_request` triggers, so the full suite (build, unit, integration, lint) ran **twice**. The existing concurrency block didn't dedupe them because the group key differed per event.

## Fix
Scope the `push` trigger to long-lived branches (`master`, `dev`) and drop `dev#*`. Feature-branch CI now comes solely from `pull_request`.

```yaml
on:
  push:
    branches: [master, dev]
  pull_request:
    branches: [master, dev]
```

This is **Option 1** from the issue. Research note: the issue's Option 3 (`github.head_ref || github.ref`) is subtly broken — `head_ref` is the short branch name while the `github.ref` fallback is fully-qualified (`refs/heads/...`), so the two events land in different concurrency groups and still run twice. Option 1 is also the community-recommended approach: it prevents the duplicate run from ever being created rather than racing to cancel it ([adamj.eu](https://adamj.eu/tech/2025/05/14/github-actions-avoid-simple-on/), [GitHub community](https://github.com/orgs/community/discussions/26940), [GitHub docs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency)).

## Acceptance criteria
- [x] A push to a `dev#*` branch with an open PR triggers the suite once, not twice.
- [x] Post-merge runs on `dev`/`master` still trigger (via `push`).
- [x] No loss of required status checks on PRs (still run via `pull_request`).

Trade-off: no pre-PR CI on feature branches — fine, since CI starts when the PR opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)