### PR TITLE
ci: add workflow_dispatch to Build and Test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - master
       - dev
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## What
Adds a `workflow_dispatch` trigger to `.github/workflows/test.yml`, allowing the **Build and Test** suite (including integration tests) to be run manually against any branch ref.

## Why
After #851 scoped the `push` trigger to `master`/`dev` and `pull_request` only fires for PRs **targeting** `master`/`dev`, a PR between two feature branches gets **no CI**. For example, PR #852 (`fix/846-setter-twr` → `dev#536`) currently runs no Build and Test job, so its integration tests never execute.

`workflow_dispatch` gives an on-demand path to validate such PRs without re-enabling the duplicate-run behavior #851 removed.

## Usage
Once merged to `dev` (and thus available on the ref), trigger via:
```
gh workflow run "Build and Test" --ref <branch>
```
or the **Run workflow** button on the Actions tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)