### PR TITLE
ci: declare least-privilege workflow-level contents: read

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,10 @@ on:
       - dev
   workflow_dispatch:
 
+
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Hardens 1 workflow(s) in this repo by declaring a workflow-level `permissions: contents: read`. Today those workflows inherit the legacy broad read-write GITHUB_TOKEN; the read-only default reduces blast radius if any step is compromised.

I checked each file - they read the checkout and run tests/lints; no GitHub API writes (no `gh pr/issue`, no `git push`, no release/publish/comment actions). So behavior is unchanged.

Reference: the tj-actions/changed-files compromise (CVE-2025-30066) is the canonical reason to apply least-privilege defaults.