### PR TITLE
fix: read suspension timestamps in UTC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -496,17 +496,6 @@
 					<excludes>
 						<exclude>**/*IT</exclude>
 					</excludes>
-					<!--
-						Pin tests to UTC so they pass deterministically on non-UTC developer
-						machines. The application reads SQL DATETIME values via JDBC
-						getTimestamp() without a Calendar, which interprets them in the JVM's
-						default timezone. With the DB in UTC and the JVM in a non-UTC zone,
-						time-based checks (suspendedUntil, startTime, lockTime, endTime) skew
-						by the JVM's UTC offset. CI runs in UTC so does not see this; local
-						runs on UTC+N developer machines fail those tests.
-						Production bug tracked in #841.
-					-->
-					<argLine>-Duser.timezone=UTC</argLine>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -519,7 +508,6 @@
 					<excludes>
 						<exclude>**/*Test*</exclude>
 					</excludes>
-					<argLine>-Duser.timezone=UTC</argLine>
 				</configuration>
 				<executions>
 					<execution>

--- a/src/it/java/dbProcs/GetterAuthIT.java
+++ b/src/it/java/dbProcs/GetterAuthIT.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.TimeZone;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
@@ -73,6 +74,30 @@ public class GetterAuthIT {
     assertNotNull(
         Getter.authUser(applicationRoot, userName, userName),
         "User should be able to authenticate after unsuspension");
+  }
+
+  @Test
+  public void suspendedUserIsRejectedWhenJvmTimezoneIsNonUtc() throws SQLException {
+    requireDatabase();
+    TimeZone originalTimeZone = TimeZone.getDefault();
+    TimeZone.setDefault(TimeZone.getTimeZone("Asia/Kolkata"));
+    try {
+      String userName = "authSuspendedNonUtcUser";
+
+      Setter.userCreate(
+          applicationRoot, null, userName, userName, "player", userName + "@test.com", false);
+      String[] user = Getter.authUser(applicationRoot, userName, userName);
+      assertNotNull(user, "User should be able to authenticate before suspension");
+
+      String userId = user[0];
+
+      assertTrue(Setter.suspendUser(applicationRoot, userId, 10), "Could not suspend user");
+      assertNull(
+          Getter.authUser(applicationRoot, userName, userName),
+          "Suspended user should not be able to authenticate under a non-UTC JVM timezone");
+    } finally {
+      TimeZone.setDefault(originalTimeZone);
+    }
   }
 
   @Test

--- a/src/it/java/dbProcs/GetterIT.java
+++ b/src/it/java/dbProcs/GetterIT.java
@@ -3,6 +3,7 @@ package dbProcs;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -14,6 +15,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Locale;
 import java.util.ResourceBundle;
+import java.util.TimeZone;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;
@@ -3191,6 +3193,29 @@ public class GetterIT {
       } else {
         log.debug("PASS: User Could Authenticate after unsuspension");
       }
+    }
+  }
+
+  @Test
+  public void testSSOAuthSuspendedWithNonUtcJvmTimeZone() {
+    TimeZone originalTimeZone = TimeZone.getDefault();
+    TimeZone.setDefault(TimeZone.getTimeZone("Asia/Kolkata"));
+    try {
+      String userName = "SSOSuspendedNonUtcUser Lastname";
+      String ssoName = "ssosuspendednonutcuser@example.com";
+
+      String[] user = Getter.authUserSSO(applicationRoot, null, userName, ssoName, "player");
+      assertNotNull(user, "Initial SSO auth should succeed");
+      assertFalse(user[0].isEmpty(), "Initial SSO auth should return a userId");
+
+      String userID = user[0];
+
+      assertTrue(Setter.suspendUser(applicationRoot, userID, 10), "Could not suspend user");
+      assertNull(
+          Getter.authUserSSO(applicationRoot, null, userName, ssoName, "player"),
+          "Suspended SSO user should not authenticate under a non-UTC JVM timezone");
+    } finally {
+      TimeZone.setDefault(originalTimeZone);
     }
   }
 

--- a/src/main/java/dbProcs/Getter.java
+++ b/src/main/java/dbProcs/Getter.java
@@ -21,6 +21,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.owasp.encoder.Encode;
 import servlets.Register;
+import utils.DbTime;
 import utils.ModulePlan;
 import utils.ScoreboardStatus;
 
@@ -112,7 +113,7 @@ public class Getter {
           badLoginCount = userResult.getInt(5);
           tempPassword = userResult.getBoolean(6);
           classId = userResult.getString(7);
-          suspendedUntil = userResult.getTimestamp(8);
+          suspendedUntil = userResult.getTimestamp(8, DbTime.utcCalendar());
           loginType = userResult.getString(9);
           tempUsername = userResult.getBoolean(10);
         } else {
@@ -237,7 +238,7 @@ public class Getter {
             // User found if a row is in the database
             userFound = true;
             log.debug("User Found");
-            suspendedUntil = userResult.getTimestamp(1);
+            suspendedUntil = userResult.getTimestamp(1, DbTime.utcCalendar());
           } else {
             userFound = false;
           }

--- a/src/main/java/utils/DbTime.java
+++ b/src/main/java/utils/DbTime.java
@@ -1,0 +1,15 @@
+package utils;
+
+import java.util.Calendar;
+import java.util.TimeZone;
+
+public final class DbTime {
+
+  private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+
+  private DbTime() {}
+
+  public static Calendar utcCalendar() {
+    return Calendar.getInstance(UTC);
+  }
+}

--- a/src/test/java/utils/DbTimeTest.java
+++ b/src/test/java/utils/DbTimeTest.java
@@ -1,0 +1,23 @@
+package utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import java.util.Calendar;
+import org.junit.jupiter.api.Test;
+
+class DbTimeTest {
+
+  @Test
+  void utcCalendarUsesUtc() {
+    assertEquals("UTC", DbTime.utcCalendar().getTimeZone().getID());
+  }
+
+  @Test
+  void utcCalendarReturnsIndependentInstances() {
+    Calendar first = DbTime.utcCalendar();
+    Calendar second = DbTime.utcCalendar();
+
+    assertNotSame(first, second);
+  }
+}


### PR DESCRIPTION
Fixes #841.

## Summary
- read `users.suspendedUntil` via JDBC with a UTC `Calendar` so DB UTC `DATETIME` values are not shifted by the JVM default timezone
- remove the forced UTC Maven test workaround now that the production reads are timezone-explicit
- add unit coverage for the UTC calendar helper and non-UTC integration coverage for suspended password and SSO authentication

## Testing
- `git diff --cached --check`
- `python3 - <<PY ... ET.parse("pom.xml") ... PY`
- Not run locally: Maven/Spotless/integration tests, because this machine has no `mvn`, no Java runtime, and no Docker available.