### PR TITLE
Upgrade to Java 21

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Build Maven with Docker Profile and Generate SBOM
         run: mvn clean install -Pdocker -DskipTests -B -DexcludeTestProject=true cyclonedx:makeBom
       - name: Upload WAR File

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: '21'
           cache: maven
       - name: Check Java formatting (Google Java Format via Spotless)
         run: mvn spotless:check -B
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: '21'
           cache: maven
       - name: Build Maven with Docker Profile
         run: mvn clean install -Pdocker -DskipTests -B
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: '21'
           cache: maven
       - name: Run Unit Tests
         run: mvn test -B -e
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: '21'
           cache: maven
       - name: Start MYSQL Server
         run: sudo /etc/init.d/mysql start

--- a/pom.xml
+++ b/pom.xml
@@ -433,7 +433,7 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.13.0</version>
 				<configuration>
-					<release>17</release>
+					<release>21</release>
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
Upgrades the build from Java 17 to Java 21 (current LTS).

- `pom.xml`: `maven-compiler-plugin` `<release>` 17 → 21
- `.github/workflows/test.yml` & `release.yml`: `java-version` 17 → 21, so CI builds on the new target (otherwise the JDK-17 runners can't compile a release-21 build)

**Verification:** the project compiles under JDK 21 and all 162 unit tests pass, with none lost versus the JDK-17 baseline. Integration tests that need external services (MongoDB/MariaDB/Docker) were not run locally and are unchanged. No production or test code was modified — only the compiler target and the CI JDK.



---
### How this was produced
The compiler-target change was produced with OpenRewrite's `UpgradeJavaVersion` recipe:

```yaml
# rewrite.yml
type: specs.openrewrite.org/v1beta/recipe
name: com.example.UpgradeJava
recipeList:
  - org.openrewrite.java.migrate.UpgradeJavaVersion:
      version: 21
```
```bash
mvn -U org.openrewrite.maven:rewrite-maven-plugin:RELEASE:run \
  -Drewrite.configLocation=$(pwd)/rewrite.yml \
  -Drewrite.activeRecipes=com.example.UpgradeJava \
  -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-migrate-java:RELEASE
```
The diff was then reduced by hand to the minimal compiler-target change, and the CI workflow `java-version` was updated to match (OpenRewrite does not edit GitHub Actions).

_Verified: all 162 tests pass under JDK 21, none lost versus the baseline._
