### PR TITLE
Fix swallowed exception in GetJson

### DIFF
--- a/src/main/java/utils/GetJson.java
+++ b/src/main/java/utils/GetJson.java
@@ -18,7 +18,7 @@ public class GetJson {
         jb.append(line);
       }
     } catch (Exception e) {
-      log.error("Unable to buffer JSON array from request.");
+      throw new RuntimeException("Unable to buffer JSON array from request.", e);
     }
     try {
       JSONArray jsonArray = new JSONArray(jb.toString());

--- a/src/test/java/utils/GetJsonTest.java
+++ b/src/test/java/utils/GetJsonTest.java
@@ -2,8 +2,10 @@ package utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.StringReader;
 import org.json.JSONArray;
 import org.junit.jupiter.api.Test;
@@ -53,5 +55,22 @@ class GetJsonTest {
   void getJsonArrayFromPost_multilineInput() {
     JSONArray result = GetJson.getJssonArrayFromPost(readerOf("[\n  1,\n  2\n]"));
     assertEquals(2, result.length());
+  }
+
+  @Test
+  void getJsonArrayFromPost_readerFailureThrowsRuntimeException() {
+    BufferedReader failingReader =
+        new BufferedReader(new StringReader("")) {
+          @Override
+          public String readLine() throws IOException {
+            throw new IOException("Simulated reader failure");
+          }
+        };
+
+    RuntimeException exception =
+        assertThrows(RuntimeException.class, () -> GetJson.getJssonArrayFromPost(failingReader));
+
+    assertEquals("Unable to buffer JSON array from request.", exception.getMessage());
+    assertEquals("Simulated reader failure", exception.getCause().getMessage());
   }
 }


### PR DESCRIPTION
Fixes issue #510 by preventing unrecoverable exceptions in GetJson from being silently ignored.

Changes:
- Replace the swallowed exception with a RuntimeException.
- Preserve the original exception as the cause.
- Add a regression test for BufferedReader failures.

Testing:
- GetJsonTest: 7 tests passed
- Spotless formatting check: passed