### PR TITLE
Fix misleading validation-failure log message in AddPlayer/CreateNewA…

### DIFF
--- a/src/main/java/servlets/admin/userManagement/AddPlayer.java
+++ b/src/main/java/servlets/admin/userManagement/AddPlayer.java
@@ -156,7 +156,15 @@ public class AddPlayer extends HttpServlet {
               log.error("Invalid Addresses Detected");
               errorMessage += "Invalid Addresses Detected";
             } else if (!userValidate) {
-              log.error("JavaScript validation bypassed");
+              log.warn(
+                  "Server-side user validation failed for new player (username length="
+                      + userName.length()
+                      + ", password length="
+                      + passWord.length()
+                      + ", address length="
+                      + userAddress.length()
+                      + "); expected: username 3-32 chars, password 8-512 chars, address <=128"
+                      + " chars");
               errorMessage += "Invalid Request. Please try again";
             } else {
               log.debug("Class Not Found");

--- a/src/main/java/servlets/admin/userManagement/CreateNewAdmin.java
+++ b/src/main/java/servlets/admin/userManagement/CreateNewAdmin.java
@@ -136,7 +136,15 @@ public class CreateNewAdmin extends HttpServlet {
               log.error("Invalid Addresses Detected");
               errorMessage += "Invalid Addresses Detected";
             } else if (!userValidate) {
-              log.error("JavaScript validation bypassed");
+              log.warn(
+                  "Server-side user validation failed for new admin (username length="
+                      + userName.length()
+                      + ", password length="
+                      + passWord.length()
+                      + ", address length="
+                      + userAddress.length()
+                      + "); expected: username 3-32 chars, password 8-512 chars, address <=128"
+                      + " chars");
               errorMessage += "Invalid Request. Please try again";
             }
             out.print(


### PR DESCRIPTION
Closes #860

## Problem
`AddPlayer.java` and `CreateNewAdmin.java` logged `log.error("JavaScript validation bypassed")` whenever `Validate.isValidUser()` rejected input, even for the routine case of e.g. a too-short password. This wrongly implied a malicious client-side bypass and gave no detail on which constraint failed.

## Fix
- Reworded the log to describe an accurate server-side validation failure, including the *lengths* of the offending fields (never the
  actual values) so operators can see which constraint was violated.
- Downgraded the log level from ERROR to WARN.
- Applied the same fix to `CreateNewAdmin.java`, which had the identical pattern.
- User-facing response message is unchanged.

## Verification
- `mvn spotless:check` - passes
- `mvn clean install -Pdocker -DskipTests` - compiles cleanly
- No existing unit or integration tests reference these servlets