### PR TITLE
fix: stop logging plaintext new password in admin password reset

### DIFF
--- a/src/main/java/servlets/admin/userManagement/ChangeUserPassword.java
+++ b/src/main/java/servlets/admin/userManagement/ChangeUserPassword.java
@@ -68,7 +68,7 @@ public class ChangeUserPassword extends HttpServlet {
           String player = (String) request.getParameter("player");
           log.debug("player = " + player.toString());
           String newPassword = (String) request.getParameter("password");
-          log.debug("newPass = " + newPassword);
+          log.debug("newPass retrieved");
 
           // Validation
           notNull = (player != null) && (newPassword != null);


### PR DESCRIPTION
Fixes #571